### PR TITLE
Avoid tuple-node grids, shrink graph defaults, and add tokenizer fallback

### DIFF
--- a/reasoning_core/tasks/graph_operations.py
+++ b/reasoning_core/tasks/graph_operations.py
@@ -17,8 +17,10 @@ _GRAPH_GENERATORS = [
     (nx.watts_strogatz_graph, {'k': (2, 4), 'p': (0.1, 0.3)}),
     (nx.barabasi_albert_graph, {'m': (1, 3)}),
     (nx.random_regular_graph, {'d': (2, 4)}), # Every node has d neighbors
-    (nx.grid_2d_graph, {'m': (3, 5), 'n': (3, 5)}), # A grid
 ]
+
+# Keep grid generation for higher levels only to avoid tuple-node complexity at level 0.
+_GRID_GENERATOR = (nx.grid_2d_graph, {'m': (3, 5), 'n': (3, 5)})
 
 
 class BaseGraphTask:
@@ -30,8 +32,12 @@ class BaseGraphTask:
             """Randomly selects a topology from the list and generates a graph."""
             num_nodes = self.config.num_nodes
             
+            graph_generators = list(_GRAPH_GENERATORS)
+            if self.config.level >= 1:
+                graph_generators.append(_GRID_GENERATOR)
+
             for _ in range(10): # Try a few times to get a valid graph
-                gen_func, params_ranges = random.choice(_GRAPH_GENERATORS)
+                gen_func, params_ranges = random.choice(graph_generators)
                 params = {'n': num_nodes}
                 try:
                     for p_name, p_range in params_ranges.items():
@@ -375,8 +381,8 @@ class BaseDirectedGraphTask:
 # DEPO-style: repeated successor chasing in a permutation digraph
 @dataclass
 class GraphSuccessorsConfig(Config):
-    num_nodes: int = 8
-    num_queries: int = 2
+    num_nodes: int = 6
+    num_queries: int = 1
     max_hops: int = 2
 
     def update(self, c=1):
@@ -437,8 +443,9 @@ class GraphSuccessors(BaseDirectedGraphTask, Task):
 # BREVO-style: dependency expansion in a DAG
 @dataclass
 class GraphDependenciesConfig(Config):
-    num_nodes: int = 8
-    max_prereqs: int = 3
+    # Smaller defaults keep dependency prompts less compositional.
+    num_nodes: int = 6
+    max_prereqs: int = 2
 
     def update(self, c=1):
         self.num_nodes += c

--- a/reasoning_core/template.py
+++ b/reasoning_core/template.py
@@ -139,6 +139,18 @@ def register_dataset(name, dataset_cls):
 
 def prepr_task_name(name):
     return underscore(name)
+
+
+def _load_tokenizer():
+    class _WhitespaceTokenizerFallback:
+        """Minimal tokenizer fallback when tiktoken assets are unavailable."""
+        def encode(self, text):
+            return str(text).split()
+
+    try:
+        return tiktoken.get_encoding("o200k_base")
+    except Exception:
+        return _WhitespaceTokenizerFallback()
     
 
 class Task(ProceduralDataset):
@@ -157,7 +169,7 @@ class Task(ProceduralDataset):
         for k,v in kwa.items():
             setattr(self.config, k, v)
         self.balancing_key_ratio = 0.5
-        self.tokenizer = tiktoken.get_encoding("o200k_base")
+        self.tokenizer = _load_tokenizer()
 
     def generate(self):
         """To override, return one problem"""


### PR DESCRIPTION
### Motivation
- Prevent `nx.grid_2d_graph` from producing tuple node labels at base difficulty and avoid confusing prompts by only using grid graphs for higher levels. 
- Reduce default graph sizes and query counts to keep generated prompts less compositional and easier to reason about. 
- Make the task code robust when `tiktoken` encoding is unavailable by providing a minimal tokenizer fallback.

### Description
- Moved the grid generator out of the main `_GRAPH_GENERATORS` list into a separate `_GRID_GENERATOR` and only append it when `self.config.level >= 1`, and ensure chosen generator is sampled from a local `graph_generators` list. 
- Keep converting nodes to integers with `nx.convert_node_labels_to_integers(G)` to prevent tuple-node complexity. 
- Adjusted defaults in `GraphSuccessorsConfig` from `num_nodes=8,num_queries=2` to `num_nodes=6,num_queries=1` and in `GraphDependenciesConfig` from `num_nodes=8,max_prereqs=3` to `num_nodes=6,max_prereqs=2` to reduce prompt complexity. 
- Added `_load_tokenizer()` that attempts `tiktoken.get_encoding("o200k_base")` and falls back to a minimal whitespace tokenizer when unavailable, and set `Task.tokenizer = _load_tokenizer()`.

### Testing
- Ran the repository's automated tests with `pytest` and verified they completed without failures. 
- Performed generation smoke tests for affected tasks by instantiating `GraphSuccessors` and `GraphDependencies` and calling their `generate()` methods; the generators produced connected integer-labeled graphs and valid problem outputs. 
- Verified that when `tiktoken` is not available the tokenizer fallback returns tokens via whitespace splitting and that task initialization succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7424dc90c8327b6ae8e8b8a78f2fb)