### PR TITLE
Standardize task prompt answer format specifications

### DIFF
--- a/reasoning_core/tasks/coding.py
+++ b/reasoning_core/tasks/coding.py
@@ -72,7 +72,7 @@ class CodeExecution(Task):
         return (
             f"Predict the printed output of the following Python code:\n\n"
             f"```python\n{metadata.code}\n```\n\n"
-            f"Return only the exact printed output string."
+            f"The answer is the exact printed output string."
         )
 
     def score_answer(self, answer, entry):
@@ -220,7 +220,7 @@ class DiffPrediction(VersionedTask, Task):
         return (f"Below is the version history of a file.\n\n"
                 f"{meta.history}\n"
                 f"Generate the Unified Diff to transform version {meta.src_id} into version {meta.tgt_id}.\n"
-                f"Answer with the diff chunks only (no file headers). If no changes, return nothing.")
+                f"The answer is the diff chunks only (no file headers), or empty if no changes.")
 
     def score_answer(self, answer, entry):
         meta = entry.get('metadata', {})
@@ -262,7 +262,7 @@ class DiffPatching(VersionedTask, Task):
                 f"{meta.src_text}\n\n"
                 f"Diff ({meta.src_id} -> {meta.tgt_id}):\n"
                 f"{meta.diff}\n\n"
-                f"Answer with the resulting text only.")
+                f"The answer is the resulting text.")
 
     def score_answer(self, answer, entry):
         return Levenshtein.normalized_similarity(answer.strip(), entry['answer'].strip())

--- a/reasoning_core/tasks/equation_system.py
+++ b/reasoning_core/tasks/equation_system.py
@@ -133,8 +133,7 @@ class EquationSystem(Task):
         eq_block = "\n".join([f"  {eq_str}" for eq_str in metadata['equations']])
         return (f"Solve the following system of equations for the variable '{metadata['query_variable']}'.\n\n"
                 f"System:\n{eq_block}\n\n"
-                f"Return the numerical value for {metadata['query_variable']}. If a unique numerical solution does not exist, "
-                "return either 'No solution' or 'Multiple solutions'.")
+                f"The answer is the numerical value for {metadata['query_variable']}, or 'No solution' / 'Multiple solutions' if a unique numerical solution does not exist.")
 
 
     def score_answer(self, answer, entry) -> float:

--- a/reasoning_core/tasks/grammar.py
+++ b/reasoning_core/tasks/grammar.py
@@ -369,7 +369,7 @@ class Parsability(Task):
             f"(GRAMMAR)\n{g}\n\n"
             f"(STRING)\n{' '.join(tokens)}\n\n"
             f"(QUESTION)\nWhat is the parsability of this string?\n"
-            f"Answer with exactly one word, unambiguous|ambiguous|unparsable"
+            f"The answer is exactly one word: unambiguous, ambiguous, or unparsable."
         )
 
 
@@ -412,7 +412,7 @@ class Parsing(Task):
         
         ex = """Given G_ex: S -> NP VP, NP -> 'd' N, N -> 'n', VP -> 'v' and "d n v", correct is (S (NP d (N n)) (VP v))."""
         return (head + 
-            "Return the fully parenthesized parse tree of STRING in Lisp style.\n"
+            "The answer is the fully parenthesized parse tree of STRING in Lisp style.\n"
             f"{ex}")
 
 
@@ -542,7 +542,7 @@ class Continuation(Task):
     def prompt(self, meta):
         pfx = ' '.join(meta.prefix) if meta.prefix else '<empty>'
         return (f"List all valid next tokens for this prefix. "
-                f"Answer sorted alphabetically separated by |, with STOP at the end if complete.\n"
+                f"The answer is the list of valid tokens sorted alphabetically and separated by |, with STOP at the end if the prefix forms a complete string.\n"
                 f"(GRAMMAR)\n{meta.g}\n(PREFIX)\n{pfx}")
 
     def score_answer(self, answer, entry):
@@ -685,7 +685,7 @@ class LocateError(Task):
         return (
             f"(GRAMMAR)\n{meta.g}\n\n"
             f"(STRING)\n{' '.join(meta.tokens)}\n\n"
-            f"Return the shortest contiguous span from STRING that ends at the first invalid token "
+            f"The answer is the shortest contiguous span from STRING that ends at the first invalid token "
             f"and occurs only once in STRING.\n"
             f"Mark the invalid token as >>token<<.\n"
             f"If the token alone is enough, answer just >>token<<.\n"
@@ -1017,7 +1017,7 @@ class ConstrainedContinuation(Task):
             f"Fill in the {nb} {bw} (___) to form a grammatical continuation "
             f"of PREFIX using exactly {meta.k} tokens.\n"
             f"Fixed tokens must remain in place. "
-            f"Return all {meta.k} tokens space-separated."
+            f"The answer is all {meta.k} tokens space-separated."
         )
 
     def score_answer(self, answer, entry):

--- a/reasoning_core/tasks/knowledge.py
+++ b/reasoning_core/tasks/knowledge.py
@@ -361,11 +361,11 @@ class LexicalKnowledge(Task):
     def prompt(self, m):
         cands = ', '.join(m.candidates)
         ctx = "Context: WordNet (relation holds for any valid noun sense)."
-        if m.answer_type == 'bool': 
-            return f"{ctx}\n\n{m.expr}\nTrue or False?"
-        if m.answer_type == 'set':  
-            return f"{ctx}\nSelect all {m.expr}\nFrom: [{cands}]\nAnswer is a JSON list."
-        return f"{ctx}\n\nSelect {m.expr}\nFrom: [{cands}]\nAnswer is one word."
+        if m.answer_type == 'bool':
+            return f"{ctx}\n\n{m.expr}\nThe answer is True or False."
+        if m.answer_type == 'set':
+            return f"{ctx}\nSelect all {m.expr}\nFrom: [{cands}]\nThe answer is a JSON list."
+        return f"{ctx}\n\nSelect {m.expr}\nFrom: [{cands}]\nThe answer is one word."
 
     def score_answer(self, answer: str, entry) -> float:
         if not answer: return 0.0

--- a/reasoning_core/tasks/logic.py
+++ b/reasoning_core/tasks/logic.py
@@ -195,7 +195,7 @@ class LogicNLI(Task):
             "If the Premise entails the Hypothesis, the label is 'entailment'.\n"
             "If the Premise contradicts the Hypothesis, the label is 'contradiction'.\n"
             "If neither, the label is 'neutral'.\n"
-            "Answer with exactly one word, neutral|contradiction|entailment"
+            "The answer is exactly one word: neutral, contradiction, or entailment."
         )
 
         P=verbalize_predicates(P, seed=meta.verbalize_seed)
@@ -241,7 +241,7 @@ class EvidenceRetrieval(Task):
             f"Premise:\n{prem}\n"
             f"Hypothesis:\n{hyp}\n\n"
             f"Which statements in the premise {verb} the hypothesis?\n"
-            f"Only answer the list of supporting statements, e.g. [0, 6, 7]."
+            f"The answer is the list of supporting statements, e.g. [0, 6, 7]."
         )
         P=verbalize_predicates(P, seed=meta.verbalize_seed)
         return P

--- a/reasoning_core/tasks/navigation.py
+++ b/reasoning_core/tasks/navigation.py
@@ -256,7 +256,7 @@ def pick_query(rng, solver, gv, names, final):
                         "type": "relation",
                         "text": (
                             f"What is the final spatial relation of {a} to {b}? "
-                            f"Answer as (horizontal, vertical), where horizontal is "
+                            f"The answer is (horizontal, vertical), where horizontal is "
                             f"left/right/aligned and vertical is above/below/aligned."
                         ),
                         "answer": f"({h}, {v})",

--- a/reasoning_core/tasks/planning.py
+++ b/reasoning_core/tasks/planning.py
@@ -521,7 +521,7 @@ class Planning(Task):
         if random.random() < self.config.hint_proba:
             txt += f"\nHint: Reference solution has {meta.na} actions (but it may not be optimal)."
         txt += (
-            "\nReturn only the plan."
+            "\nThe answer is the plan."
             "\nFormat: Multiple lines, one action per line: action(obj1, obj2)"
         )
         return txt

--- a/reasoning_core/tasks/regex_following.py
+++ b/reasoning_core/tasks/regex_following.py
@@ -187,7 +187,7 @@ class RegexFollowing(Task):
 
     def prompt(self, meta):
         n = len(meta.string)
-        return f"Return exactly a {n}-character string that fully matches the regular expression: {meta.regex}"
+        return f"The answer is a {n}-character string that fully matches the regular expression: {meta.regex}"
 
     def balancing_key(self, problem):
         return problem.metadata.regex
@@ -247,7 +247,7 @@ class RegexInduction(Task):
         pos_examples = ', '.join(f"'{s}'" for s in meta['positives'])
         neg_examples = ', '.join(f"'{s}'" for s in meta['negatives'])
         return (
-            f"Return the shortest regex that fully matches all POSITIVE strings and none of the NEGATIVE strings.\n"
+            f"The answer is the shortest regex that fully matches all POSITIVE strings and none of the NEGATIVE strings.\n"
             f"POSITIVE: {pos_examples}\n"
             f"NEGATIVE: {neg_examples}"
         )

--- a/reasoning_core/tasks/sequential_induction.py
+++ b/reasoning_core/tasks/sequential_induction.py
@@ -284,14 +284,14 @@ class SequentialInduction(Task):
         lines += [
             f"- Previous terms must be referenced exactly as: U[n - 1] ... U[n - {d}]",
             '- You may use "n" (current index).',
-            '- Output ONLY the right-hand side (do not write "U[n] =").',
+            '- The answer is the right-hand side only (do not write "U[n] =").',
             f"- Your recurrence degree must be <= {d}.",
             "",
             f"Sequence: {metadata['first elements']}",
             f"Degree of recurrence: {d}",
             f"Initial terms: {metadata['initial terms']}",
             "",
-            "Answer must hold for all n >= d and be as simple as possible.",
+            "The answer must hold for all n >= d and be as simple as possible.",
         ]
 
         return "\n".join(lines)

--- a/reasoning_core/tasks/set_operations.py
+++ b/reasoning_core/tasks/set_operations.py
@@ -126,7 +126,7 @@ class SetIntersection(Task):
         return (
             f"Set1: {metadata['set_1']}\n"
             f"Set2: {metadata['set_2']}\n"
-            "Only return the intersection of Set1 and Set2 as a Python set: {elem_1, elem_2, ..., elem_n}."
+            "The answer is the intersection of Set1 and Set2 as a Python set: {elem_1, elem_2, ..., elem_n}."
         )
 
     def score_answer(self, answer, entry):
@@ -168,7 +168,7 @@ class SetMissingElement(Task):
     def prompt(self, metadata) -> str:
         return (
             f"Set_A: {metadata['element_list']}\n"
-            "Only return the missing elements from Set_A as a Python set."
+            "The answer is the missing elements from Set_A as a Python set."
         )
 
     def score_answer(self, answer, entry):
@@ -204,7 +204,7 @@ class CountElements(Task):
         return Problem(metadata={'elements': elements, 'target': target}, answer=str(count))
 
     def prompt(self, metadata) -> str:
-        return f"List: {metadata['elements']}\nHow many times does {metadata['target']!r} appear? Only return the number."
+        return f"List: {metadata['elements']}\nHow many times does {metadata['target']!r} appear? The answer is a number."
 
     def score_answer(self, answer, entry):
         try: return 1 / (1 + abs(int(answer.strip()) - int(entry['answer'])))
@@ -234,7 +234,7 @@ class SetEquality(Task):
         return (
             f"Set1: {metadata['base_subset']}\n"
             f"Set2: {metadata['subset_bis']}\n"
-            "Only return True if Set1 and Set2 contain exactly the same elements, False otherwise."
+            "The answer is True if Set1 and Set2 contain exactly the same elements, False otherwise."
         )
     
 

--- a/reasoning_core/tasks/table_qa.py
+++ b/reasoning_core/tasks/table_qa.py
@@ -149,7 +149,7 @@ class TableQA(Task):
         else:
             preamble = "The following tables are row-wise shards of one logical table named dataframe. Concatenate them in order to reconstruct dataframe, then execute the SQL query:"
         presentation = "\n\n".join(f"Table {i}:\n{table}" for i, table in enumerate(tables, 1))
-        return f"{preamble}\n\n{presentation}\n\nSQL: {m['query']}\n\nReturn result as {fmt}."
+        return f"{preamble}\n\n{presentation}\n\nSQL: {m['query']}\n\nThe answer is the result as {fmt}."
 
     def score_answer(self, ans, entry):
         def isnumeric(x):

--- a/reasoning_core/tasks/table_qa.py
+++ b/reasoning_core/tasks/table_qa.py
@@ -216,7 +216,7 @@ class TableConversion(Task):
         return (
             f"Convert the following table from {m['source_format']} to {m['target_format']}.\n\n"
             f"{m['source_table']}\n\n"
-            f"Output only the converted table."
+            f"The answer is the converted table."
         )
 
     def score_answer(self, answer, entry):


### PR DESCRIPTION
## Summary

- Replace all variations of `"Answer with only X"`, `"Output only X"`, `"Return X"`, `"Only return X"`, `"Output ONLY X"`, `"Answer is X"` with the uniform phrasing `"The answer is X"` across all task `prompt()` methods
- Covers all 16 task files that define prompt methods
- Format specifications are preserved exactly; only the phrasing wrapper changes

## Motivation

Decouples answer format specification from output-control instructions. Previously, "answer only" behaviour was baked into each task's prompt (e.g. `"Answer with only a number."`). Now, all prompts describe the answer format uniformly using `"The answer is..."`, so a single system prompt addition like `"directly output the answer"` can control verbosity across all tasks without touching individual prompts.

## Files changed

`arithmetics`, `causal_reasoning`, `constraint_satisfaction`, `formal_maths`, `graph_operations`, `rung3_reasoning`, `planning`, `table_qa`, `equation_system`, `logic`, `grammar`, `sequential_induction`, `knowledge`, `coding`, `regex_following`, `set_operations`, `navigation`

https://claude.ai/code/session_0143i39fPHbtw3UQrQbJqP28