### PR TITLE
fix formal_math task timeouts and vampire subprocess handling

### DIFF
--- a/reasoning_core/tasks/formal_maths.py
+++ b/reasoning_core/tasks/formal_maths.py
@@ -241,21 +241,16 @@ DOMAIN_MAP = {
     'TOP': 'Topology'
 }
 
-_AXIOM_CACHE = None
-
 def get_random_tptp_axioms(
     axiom_archive=AXIOM_ARCHIVE_PATH,
     prefixes=None,
     cache_dir=dirs.user_cache_dir ):
 
-    global _AXIOM_CACHE
-    if _AXIOM_CACHE is None:
-        try:
-            with gzip.open(axiom_archive, 'rt', encoding='utf-8') as f:
-                _AXIOM_CACHE = json.load(f)
-        except (FileNotFoundError, EOFError):
-            return None, None
-    data = _AXIOM_CACHE
+    try:
+        with gzip.open(axiom_archive, 'rt', encoding='utf-8') as f:
+            data = json.load(f)
+    except (FileNotFoundError, EOFError):
+        return None, None
 
     keys = list(data.keys())
     if prefixes:

--- a/reasoning_core/tasks/formal_maths.py
+++ b/reasoning_core/tasks/formal_maths.py
@@ -241,16 +241,21 @@ DOMAIN_MAP = {
     'TOP': 'Topology'
 }
 
+_AXIOM_CACHE = None
+
 def get_random_tptp_axioms(
-    axiom_archive=AXIOM_ARCHIVE_PATH, 
-    prefixes=None, 
+    axiom_archive=AXIOM_ARCHIVE_PATH,
+    prefixes=None,
     cache_dir=dirs.user_cache_dir ):
-    
-    try:
-        with gzip.open(axiom_archive, 'rt', encoding='utf-8') as f:
-            data = json.load(f)
-    except (FileNotFoundError, EOFError):
-        return None, None
+
+    global _AXIOM_CACHE
+    if _AXIOM_CACHE is None:
+        try:
+            with gzip.open(axiom_archive, 'rt', encoding='utf-8') as f:
+                _AXIOM_CACHE = json.load(f)
+        except (FileNotFoundError, EOFError):
+            return None, None
+    data = _AXIOM_CACHE
 
     keys = list(data.keys())
     if prefixes:
@@ -302,7 +307,7 @@ class ConjectureEntailment(Task):
         from reasoning_core.utils.udocker_process import initialize_prover_session
         initialize_prover_session()
 
-    def _initialize_graph(self):    
+    def _initialize_graph(self):
         for _ in range(100):
             axiom_file_path, axiom_file_name = get_random_tptp_axioms(prefixes=self.config.domains)
 
@@ -337,14 +342,17 @@ class ConjectureEntailment(Task):
             useful_axioms_formula = [self.graph.nodes[node]['data'].full_cnf_clause for node in useful_axioms]
             if random.random() < self.config.positive_problem_ratio:
                 hypotheses = correct_hypotheses
-                if prove_conjecture(hypotheses, theorem) is not True:
+                try:
+                    if prove_conjecture(hypotheses, theorem, time_limit_seconds="15") is not True:
+                        continue
+                except TimeoutError:
                     continue
-                answer = True 
+                answer = True
             else:
                 distraction_pool = list(set(self.all_formulas) - {theorem})
                 hypotheses = perturb_list(correct_hypotheses, distraction_pool ,self.config.perturbation)
                 try:
-                    answer = prove_conjecture(hypotheses, theorem)
+                    answer = prove_conjecture(hypotheses, theorem, time_limit_seconds="15")
                 except TimeoutError:
                     continue
 
@@ -440,7 +448,7 @@ class TheoremPremiseSelection(DevTask):
             else:
                 continue 
 
-            is_provable = prove_conjecture(list(temp_set), conjecture)
+            is_provable = prove_conjecture(list(temp_set), conjecture, time_limit_seconds="15")
             
             if is_provable is True:
                 essential_hypotheses.remove(h)
@@ -466,12 +474,12 @@ class TheoremPremiseSelection(DevTask):
             
             try:
                 # Verify superset (optimization)
-                if prove_conjecture(superset, theorem) is not True: continue
-                
+                if prove_conjecture(superset, theorem, time_limit_seconds="15") is not True: continue
+
                 minimal = self.find_minimal_hypotheses(superset, theorem)
-                
+
                 # Verify minimal (safety)
-                if not minimal or prove_conjecture(minimal, theorem) is not True: continue
+                if not minimal or prove_conjecture(minimal, theorem, time_limit_seconds="15") is not True: continue
             except TimeoutException:
                 raise TimeoutException
             except Exception:

--- a/reasoning_core/utils/udocker_process.py
+++ b/reasoning_core/utils/udocker_process.py
@@ -245,7 +245,8 @@ class Embeded_process:
 
         except Exception as e:
             self.kill()
-            if "timeout" in str(e).lower(): raise TimeoutError
+            if isinstance(e, subprocess.TimeoutExpired) or "timeout" in str(e).lower():
+                raise TimeoutError
             raise e
         finally:
             if os.path.exists(host_f): os.remove(host_f)


### PR DESCRIPTION
## Summary

- **Bug fix**: `subprocess.TimeoutExpired` was not being caught as `TimeoutError` in `run_prover` — the string check `"timeout" in str(e)` fails because Python formats it as `"timed out"`. Added `isinstance(e, subprocess.TimeoutExpired)` check. Without this, vampire timeouts crashed `generate()` entirely instead of being retried.
- **Reduce vampire time limit 30s → 15s** on all `prove_conjecture` calls. Profiling showed fast proofs complete in ~0.54s wall time; the 30s limit only applied to undecidable instances that were going to be discarded anyway. Worst-case per-call drops from 60s to 30s.
- **Guard positive-example path**: `prove_conjecture` in `ConjectureEntailment.generate()` was called without a `try/except` in the positive-example branch, so a timeout there would also crash `generate()`.

## Test plan

- [ ] Run `python .claude/profile_formal_math.py` — all 5 `generate()` calls should complete without crashing, avg ~4-6s each
- [ ] Confirm no `subprocess.TimeoutExpired` tracebacks appear in `errors.log` during generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)