### PR TITLE
[codex] add logic downstream evals

### DIFF
--- a/reasoning_core/downstream_eval/__init__.py
+++ b/reasoning_core/downstream_eval/__init__.py
@@ -2,6 +2,7 @@ import lm_eval
 from lm_eval.models.huggingface import HFLM
 from lm_eval.api.task import ConfigurableTask
 import numpy as np
+import datasets.config
 from transformers import DataCollatorForSeq2Seq
 from datasets import disable_progress_bar, get_dataset_config_names, load_dataset
 from tqdm.auto import tqdm
@@ -35,7 +36,63 @@ harness_tasks = ['leaderboard_bbh',
     "cola", "sst2", "mnli", "qnli", "rte", "boolq", "copa", "cb",'commonsense_qa',
     "swag", "piqa", "openbookqa", "sciq", "triviaqa","arc_easy",'arc_challenge', "lambada_openai","lambada_standard",
     "tinyMMLU", "tinyHellaswag", "tinyWinogrande", "tinyArc", "tinyGSM8k", "winogrande",
+    "logiqa", "anli_r1", "anli_r2", "anli_r3",
     ]     #social_iqa wsc prost: not working
+
+logic_custom_task_configs = {
+    "wanli": {
+        "task": "wanli",
+        "dataset_path": "alisawuffles/WANLI",
+        "validation_split": "test",
+        "output_type": "multiple_choice",
+        "doc_to_text": "Premise: {{premise}}\nHypothesis: {{hypothesis}}\nLabel:",
+        "doc_to_choice": '["entailment", "neutral", "contradiction"]',
+        "doc_to_target": '{{["entailment", "neutral", "contradiction"].index(gold)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+    "hans": {
+        "task": "hans",
+        "dataset_path": "hans",
+        "dataset_name": "plain_text",
+        "validation_split": "validation",
+        "output_type": "multiple_choice",
+        "doc_to_text": "Premise: {{premise}}\nHypothesis: {{hypothesis}}\nLabel:",
+        "doc_to_choice": '["entailment", "non-entailment"]',
+        "doc_to_target": "{{label}}",
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+    "nan_nli": {
+        "task": "nan_nli",
+        "dataset_path": "joey234/nan-nli",
+        "training_split": "train",
+        "test_split": "train",
+        "output_type": "multiple_choice",
+        "doc_to_text": "Premise: {{premise}}\nHypothesis: {{hypothesis}}\nLabel:",
+        "doc_to_choice": '["entailment", "neutral", "contradiction"]',
+        "doc_to_target": '{{["entailment", "neutral", "contradiction"].index(label)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+    "folio": {
+        "task": "folio",
+        "dataset_path": "tasksource/folio",
+        "validation_split": "validation",
+        "output_type": "multiple_choice",
+        "doc_to_text": "Premises:\n{{premises}}\nConclusion: {{conclusion}}\nLabel:",
+        "doc_to_choice": '["True", "False", "Uncertain"]',
+        "doc_to_target": '{{["True", "False", "Uncertain"].index(label)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+    "boardgameqa": {
+        "task": "boardgameqa",
+        "dataset_path": "1-800-LLMs/Boardgame-QA",
+        "validation_split": "validation",
+        "output_type": "multiple_choice",
+        "doc_to_text": "{{example}}\nAnswer:",
+        "doc_to_choice": '["proved", "disproved", "unknown"]',
+        "doc_to_target": '{{["proved", "disproved", "unknown"].index(label)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+}
 
 custom_tasks = {
     name: ConfigurableTask(config={
@@ -51,6 +108,7 @@ custom_tasks = {
         ("zorro", "tasksource/zorro"),
     ]
 }
+custom_tasks.update({name: ConfigurableTask(config=config) for name, config in logic_custom_task_configs.items()})
 
 tasksource = ['ConTRoL-nli', 'folio','anli/a1','WANLI','sick/label','glue/rte','glue/cola','cladder']
 
@@ -132,7 +190,8 @@ def add_bbh0(s, hflm, task_manager, limit=200):
     return s
 
 
-def run_harness(model, tokenizer, limit=200):
+def run_harness(model, tokenizer, limit=200, trust_remote_code=True):
+    datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = trust_remote_code
     hflm = HFLM(pretrained=model, tokenizer=tokenizer, batch_size="auto")
     task_manager = TaskManager()
 

--- a/reasoning_core/downstream_eval/logic.py
+++ b/reasoning_core/downstream_eval/logic.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+
+import datasets.config
+from lm_eval.api.task import ConfigurableTask
+from lm_eval.evaluator import evaluate
+from lm_eval.models.huggingface import HFLM
+from lm_eval.tasks import TaskManager, get_task_dict
+from tabulate import tabulate
+
+from reasoning_core.downstream_eval import logic_custom_task_configs, pick_metric
+
+
+BUILTIN_LOGIC_TASKS = (
+    "logiqa",
+    "anli_r1",
+    "anli_r2",
+    "anli_r3",
+    "mnli",
+    "rte",
+    "qnli",
+    "cb",
+)
+
+CUSTOM_LOGIC_TASKS = ("wanli", "hans", "nan_nli", "folio", "reclor", "boardgameqa")
+LOGIC_TASKS = BUILTIN_LOGIC_TASKS + CUSTOM_LOGIC_TASKS
+
+
+CUSTOM_TASK_CONFIGS = {
+    **logic_custom_task_configs,
+    "reclor": {
+        "task": "reclor",
+        "dataset_path": "reclor",
+        "validation_split": "validation",
+        "output_type": "multiple_choice",
+        "doc_to_text": "{{context}}\nQuestion: {{question}}\nAnswer:",
+        "doc_to_choice": "{{answers}}",
+        "doc_to_target": '{{["A", "B", "C", "D"].index(label)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+}
+
+
+@dataclass
+class LogicResult:
+    task: str
+    metric: str
+    score: float | None
+    n: int
+    seconds: float
+    status: str = "ok"
+
+
+def _metric_name(metrics: dict) -> str:
+    return next((k for k in ("mcc,none", "acc_norm,none", "acc,none") if k in metrics), "")
+
+
+def _print_table(rows: list[LogicResult]) -> None:
+    print(
+        tabulate(
+            [
+                [
+                    r.task,
+                    r.metric,
+                    "" if r.score is None else f"{r.score:.4f}",
+                    r.n,
+                    f"{r.seconds:.1f}",
+                    r.status,
+                ]
+                for r in rows
+            ],
+            headers=["task", "metric", "score", "limit", "sec", "status"],
+        )
+    )
+
+
+def available_logic_tasks(tasks: tuple[str, ...] = LOGIC_TASKS) -> list[str]:
+    manager = TaskManager()
+    return [task for task in tasks if manager.match_tasks([task]) or task in CUSTOM_TASK_CONFIGS]
+
+
+def evaluate_logic(
+    model: str = "HuggingFaceTB/SmolLM2-135M-Instruct",
+    tasks: tuple[str, ...] = LOGIC_TASKS,
+    limit: int = 5,
+    batch_size: int | str = 1,
+    device: str = "cpu",
+    timeout_s: float | None = None,
+    trust_remote_code: bool = False,
+) -> dict[str, float]:
+    datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = trust_remote_code
+    hflm = HFLM(pretrained=model, batch_size=batch_size, device=device)
+    manager = TaskManager()
+    rows: list[LogicResult] = []
+
+    for task in tasks:
+        start = time.time()
+        try:
+            if task in CUSTOM_TASK_CONFIGS:
+                task_dict = {task: ConfigurableTask(config=CUSTOM_TASK_CONFIGS[task])}
+            elif manager.match_tasks([task]):
+                task_dict = get_task_dict([task], manager)
+            else:
+                raise ValueError("not found in lm-eval")
+            metrics = evaluate(lm=hflm, task_dict=task_dict, limit=limit)["results"][task]
+            metric = _metric_name(metrics)
+            rows.append(LogicResult(task, metric, pick_metric(metrics), limit, time.time() - start))
+        except Exception as exc:
+            rows.append(LogicResult(task, "", None, limit, time.time() - start, f"skip: {exc}"))
+
+        _print_table(rows)
+        if timeout_s is not None and rows[-1].seconds > timeout_s:
+            print(f"aborting after {task}: exceeded {timeout_s}s")
+            break
+
+    return {r.task: r.score for r in rows if r.score is not None}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="HuggingFaceTB/SmolLM2-135M-Instruct")
+    parser.add_argument("--tasks", nargs="*", default=list(LOGIC_TASKS))
+    parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument("--batch-size", default="1")
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--timeout-s", type=float, default=None)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    args = parser.parse_args()
+
+    batch_size: int | str = int(args.batch_size) if args.batch_size.isdigit() else args.batch_size
+    evaluate_logic(
+        model=args.model,
+        tasks=tuple(args.tasks),
+        limit=args.limit,
+        batch_size=batch_size,
+        device=args.device,
+        timeout_s=args.timeout_s,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/reasoning_core/downstream_eval/test_evals.py
+++ b/reasoning_core/downstream_eval/test_evals.py
@@ -1,0 +1,14 @@
+from reasoning_core.downstream_eval.logic import evaluate_logic
+
+
+def test_logic_smoke():
+    scores = evaluate_logic(
+        model="HuggingFaceTB/SmolLM2-135M-Instruct",
+        tasks=("logiqa", "rte"),
+        limit=2,
+        batch_size=1,
+        device="cpu",
+        timeout_s=180,
+        trust_remote_code=True,
+    )
+    assert scores


### PR DESCRIPTION
## Summary

Adds a focused logic downstream eval surface built on lm-eval harness tasks.

- Converts `reasoning_core.downstream_eval` from a module into a package while preserving existing imports used by `run_sft.py`.
- Adds built-in logic harness tasks to default `run_harness()`: LogiQA and ANLI rounds, with existing NLI tasks retained.
- Adds concise `ConfigurableTask` definitions for WANLI, HANS, NaN-NLI, FOLIO, and BoardgameQA.
- Adds `reasoning_core.downstream_eval.logic` for tiny CPU-friendly logic-only eval runs and progressive result tables.
- Keeps ReClor available only in the explicit logic runner because the HF dataset requires manual local data.

## Validation

- `python -m py_compile reasoning_core/downstream_eval/__init__.py reasoning_core/downstream_eval/logic.py reasoning_core/downstream_eval/test_evals.py reasoning_core/training/run_sft.py`
- Verified `from reasoning_core.downstream_eval import run_harness, run_platinum` still works.
- Verified default harness task names resolve with `TaskManager`.
- Ran direct smoke: `test_logic_smoke()` with `HuggingFaceTB/SmolLM2-135M-Instruct`, `limit=2`, CPU.