### PR TITLE
[codex] add MathQA and GSM8K-MC downstream evals

### DIFF
--- a/reasoning_core/downstream_eval/__init__.py
+++ b/reasoning_core/downstream_eval/__init__.py
@@ -131,6 +131,26 @@ logic_custom_task_configs = {
         "doc_to_target": '{{["yes", "no"].index(answer)}}',
         "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
     },
+    "math_qa": {
+        "task": "math_qa",
+        "dataset_path": "regisss/math_qa",
+        "validation_split": "validation",
+        "output_type": "multiple_choice",
+        "doc_to_text": "{{Problem}}\n{{options}}\nAnswer:",
+        "doc_to_choice": '["a", "b", "c", "d", "e"]',
+        "doc_to_target": '{{["a", "b", "c", "d", "e"].index(correct)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
+    "gsm8k_mc": {
+        "task": "gsm8k_mc",
+        "dataset_path": "guipenedo/gsm8k-mc",
+        "test_split": "test",
+        "output_type": "multiple_choice",
+        "doc_to_text": "{{Question}}\nA) {{A}}\nB) {{B}}\nC) {{C}}\nD) {{D}}\nAnswer:",
+        "doc_to_choice": '["A", "B", "C", "D"]',
+        "doc_to_target": '{{["A", "B", "C", "D"].index(Answer)}}',
+        "metric_list": [{"metric": "acc", "aggregation": "mean", "higher_is_better": True}],
+    },
 }
 
 custom_tasks = {

--- a/reasoning_core/downstream_eval/logic.py
+++ b/reasoning_core/downstream_eval/logic.py
@@ -26,7 +26,7 @@ BUILTIN_LOGIC_TASKS = (
 CUSTOM_LOGIC_TASKS = (
     "wanli", "hans", "nan_nli", "folio", "logiqa2_nli",
     "semantic_fragments_nli", "control_nli", "commonsense_qa_2",
-    "reclor", "boardgameqa",
+    "math_qa", "gsm8k_mc", "reclor", "boardgameqa",
 )
 LOGIC_TASKS = BUILTIN_LOGIC_TASKS + CUSTOM_LOGIC_TASKS
 


### PR DESCRIPTION
## Summary

Adds two concise multiple-choice downstream eval tasks.

- Adds `regisss/math_qa` as `math_qa`, prompting with `Problem` and `options`, scoring over labels `a` through `e`.
- Adds `guipenedo/gsm8k-mc` as `gsm8k_mc`, prompting with `Question` and A-D options, scoring over labels `A` through `D`.
- Includes both tasks in default custom harness evals and the logic-only runner task list.

## Validation

- `python -m py_compile reasoning_core/downstream_eval/__init__.py reasoning_core/downstream_eval/logic.py reasoning_core/training/run_sft.py`
- Verified `math_qa default True` and `math_qa logic True`.
- Verified `gsm8k_mc default True` and `gsm8k_mc logic True`.
- Tiny CPU evals with `HuggingFaceTB/SmolLM2-135M-Instruct`:
  - `math_qa`, limit 10: `acc,none = 0.20`, 5.0s
  - `gsm8k_mc`, limit 10: `acc,none = 0.30`, 10.9s