### PR TITLE
[codex] add RC taskmix ablation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ unsloth_compiled_cache/
 
 # Temporary files
 =[0-9]*
+*.swp
 
 # OS generated files
 .DS_Store
@@ -66,11 +67,15 @@ Thumbs.db
 reasoning_core/generated_data/
 reasoning_core/checkpoints/
 reasoning_core/wandb/
+checkpoints/
+run_logs/
+wandb/
 
 *.xls
 *.pkl
 *.xlsx
 *.log
+*.jsonl
 
 
 ROADMAP.md

--- a/configs/task_groups_v1.json
+++ b/configs/task_groups_v1.json
@@ -1,0 +1,67 @@
+{
+  "groups": {
+    "language": [
+      "binding",
+      "constrained_continuation",
+      "continuation",
+      "coreference",
+      "grammar",
+      "knowledge",
+      "lexical_knowledge",
+      "parsability",
+      "parsing",
+      "qstr",
+      "reference_tracking",
+      "table_conversion",
+      "table_qa"
+    ],
+    "logic": [
+      "bayesian_association",
+      "bayesian_intervention",
+      "causal_reasoning",
+      "conjecture_entailment",
+      "constraint_satisfaction",
+      "evidence_retrieval",
+      "lambda_reduction",
+      "logic",
+      "logic_formalization",
+      "logic_nli",
+      "proof_reconstruction",
+      "qualitative_reasoning",
+      "term_unification",
+      "planning"
+    ],
+    "math": [
+      "arithmetics",
+      "count_elements",
+      "equation_system",
+      "formal_maths",
+      "set_equality",
+      "set_intersection",
+      "set_missing_element",
+      "set_operations"
+    ],
+    "code": [
+      "code_diff",
+      "code_execution",
+      "code_program_synthesis",
+      "diff_patching",
+      "diff_prediction",
+      "locate_error"
+    ],
+    "structure": [
+      "graph_dependencies",
+      "graph_isomorphism",
+      "graph_operations",
+      "graph_pathfinding",
+      "graph_successors",
+      "navigation",
+      "regex",
+      "regex_following",
+      "regex_induction",
+      "regex_reasoning",
+      "sequential_induction",
+      "tracking"
+    ]
+  }
+}

--- a/reasoning_core/training/README_taskmix_ablation.md
+++ b/reasoning_core/training/README_taskmix_ablation.md
@@ -1,0 +1,57 @@
+# RC Taskmix Ablation
+
+Estimates which RC task groups help FineWeb LM loss more or less, while keeping the RC auxiliary budget fixed. Dropped RC examples are replaced by later RC examples, so the estimand is:
+
+```text
+task group vs the rest of RC, conditional on fixed aux_ratio
+```
+
+Use separate `aux_ratio` sweeps to estimate total RC usefulness.
+
+## Run
+
+```bash
+PYTHONPATH=$PWD python reasoning_core/training/run_sft.py \
+  --main_data fw \
+  --aux_data rc \
+  --aux_ratio 0.4 \
+  --token_budget 200M \
+  --iterable_mode True \
+  --ablation_group_map configs/task_groups_v1.json \
+  --ablation_unit task \
+  --ablation_control_frac 0.2 \
+  --ablation_log_path run_logs/mix_ablation.jsonl \
+  --n_eval 20
+```
+
+Task-level ablation is the default, with rates `0,0.25,0.5,1`. Window length is chosen from the expected step budget to target repeated schedule coverage, bounded by `--ablation_min_window_steps` and `--ablation_max_window_steps`. Use `--ablation_unit group` for faster group-level smoke tests.
+
+## Analyze
+
+```bash
+PYTHONPATH=$PWD python reasoning_core/training/analyze_mix_ablation.py \
+  run_logs/mix_ablation.jsonl
+```
+
+Output:
+
+```text
+unit | best_drop_rate | recommended_keep_ratio | stderr
+```
+
+Interpretation:
+
+- Higher `best_drop_rate`: dropping this unit improved FineWeb loss, so keep less of it.
+- Lower `best_drop_rate`: dropping this unit did not help, or hurt, so keep more of it.
+- `recommended_keep_ratio = 1 - best_drop_rate`.
+
+The analyzer regresses local loss deltas on previous loss, a quadratic step trend, and current/lagged ablation terms. On the 50M smoke run this beat naive/AutoETS one-step loss-curve baselines; avoid higher-degree step polynomials unless a longer run justifies them.
+
+Online W&B ratio logging is enabled by default after enough rows:
+
+```text
+mix_ablation/recommended_keep_ratio/{unit}
+mix_ablation/best_drop_rate/{unit}
+mix_ablation/stderr/{unit}
+mix_ablation/effect/{unit}
+```

--- a/reasoning_core/training/analyze_mix_ablation.py
+++ b/reasoning_core/training/analyze_mix_ablation.py
@@ -1,0 +1,137 @@
+import argparse
+import json
+
+import numpy as np
+import pandas as pd
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_path")
+    parser.add_argument("--step_df", type=int, default=2)
+    parser.add_argument("--unit_col", type=str, default="auto")
+    args = parser.parse_args()
+
+    result = analyze_log_path(args.log_path, step_df=args.step_df, unit_col=args.unit_col)
+    print(format_recommendations(result))
+
+
+def analyze_log_path(log_path, step_df=2, unit_col="auto"):
+    rows = load_rows(log_path)
+    if not rows:
+        raise ValueError(f"No rows found in {log_path}")
+    return fit_recommendations(rows, step_df=step_df, unit_col=unit_col)
+
+
+def load_rows(log_path):
+    rows = []
+    with open(log_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def fit_recommendations(rows, step_df=2, unit_col="auto"):
+    df = pd.DataFrame(rows)
+    df = df.dropna(subset=["eval_main_loss_delta", "eval_main_loss"]).copy()
+    if df.empty:
+        raise ValueError("No rows with eval_main_loss_delta and eval_main_loss")
+
+    unit_cols = _resolve_unit_columns(df, unit_col)
+    df["previous_loss"] = df["eval_main_loss"] - df["eval_main_loss_delta"]
+    design = _build_design(df, step_df, unit_cols)
+    y = df["eval_main_loss_delta"].to_numpy(dtype=float)
+
+    beta, stderr = _ols(y, design.to_numpy(dtype=float))
+    coef = pd.Series(beta, index=design.columns)
+    se = pd.Series(stderr, index=design.columns)
+
+    groups = sorted(
+        g for g in df[unit_cols[0][1]].dropna().unique()
+        if str(g) not in ("", "None", "nan")
+    )
+    rates = sorted(float(r) for r in df["drop_rate"].dropna().unique())
+
+    out = []
+    for group in groups:
+        estimates = []
+        for rate in rates:
+            col = _term(group, rate)
+            if col in coef:
+                estimates.append((rate, coef[col], se[col]))
+        if not estimates:
+            continue
+        best_rate, best_effect, best_se = min(estimates, key=lambda x: x[1])
+        out.append({
+            "unit": group,
+            "best_drop_rate": best_rate,
+            "recommended_keep_ratio": 1.0 - best_rate,
+            "stderr": best_se,
+            "effect": best_effect,
+        })
+
+    result = pd.DataFrame(out)
+    if result.empty:
+        raise ValueError("No target unit x drop_rate terms found")
+    result = result.sort_values(["recommended_keep_ratio", "unit"], ascending=[False, True])
+    return result
+
+
+def format_recommendations(result):
+    return result[["unit", "best_drop_rate", "recommended_keep_ratio", "stderr"]].to_string(index=False)
+
+
+def _build_design(df, step_df, unit_cols):
+    parts = [
+        pd.Series(1.0, index=df.index, name="intercept"),
+        df["previous_loss"].astype(float).rename("previous_loss"),
+    ]
+    step = df["step"].astype(float)
+    if step.nunique() > 1:
+        x = (step - step.min()) / (step.max() - step.min())
+        for degree in range(1, max(1, step_df) + 1):
+            parts.append((x ** degree).rename(f"step_poly_{degree}"))
+
+    for prefix, unit_column, rate_col in unit_cols:
+        if unit_column not in df or rate_col not in df:
+            continue
+        for unit, rate in sorted(set(zip(df[unit_column], df[rate_col])), key=lambda x: str(x)):
+            if pd.isna(unit) or pd.isna(rate):
+                continue
+            name = prefix + _term(str(unit), float(rate))
+            parts.append(((df[unit_column] == unit) & (df[rate_col].astype(float) == float(rate))).astype(float).rename(name))
+
+    return pd.concat(parts, axis=1)
+
+
+def _resolve_unit_columns(df, unit_col):
+    if unit_col == "auto":
+        base = "target_unit" if "target_unit" in df else "target_group"
+    else:
+        base = unit_col
+    return [
+        ("", base, "drop_rate"),
+        ("lag1_", f"lag1_{base}", "lag1_drop_rate"),
+        ("lag2_", f"lag2_{base}", "lag2_drop_rate"),
+    ]
+
+
+def _ols(y, x):
+    beta, *_ = np.linalg.lstsq(x, y, rcond=None)
+    resid = y - x @ beta
+    dof = max(1, x.shape[0] - np.linalg.matrix_rank(x))
+    sigma2 = float(resid @ resid) / dof
+    cov = sigma2 * np.linalg.pinv(x.T @ x)
+    stderr = np.sqrt(np.maximum(np.diag(cov), 0.0))
+    return beta, stderr
+
+
+def _term(group, rate):
+    safe_group = str(group).replace("/", "_").replace(" ", "_")
+    safe_rate = ("%g" % float(rate)).replace(".", "p")
+    return f"target_group[{safe_group}]:drop_rate[{safe_rate}]"
+
+
+if __name__ == "__main__":
+    main()

--- a/reasoning_core/training/mix_ablation.py
+++ b/reasoning_core/training/mix_ablation.py
@@ -1,0 +1,355 @@
+import argparse
+import json
+import random
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+
+from datasets import IterableDataset
+from transformers import TrainerCallback
+
+
+__all__ = [
+    "add_mix_ablation_args",
+    "wrap_aux_dataset_with_ablation",
+    "MixAblationCallback",
+]
+
+
+def add_mix_ablation_args(parser):
+    parser.add_argument("--mix_ablation", type=_str_to_bool, nargs="?", const=True, default=True)
+    parser.add_argument("--ablation_group_map", type=str, default="configs/task_groups_v1.json")
+    parser.add_argument("--ablation_unit", choices=("group", "task"), default="task")
+    parser.add_argument("--ablation_drop_rates", type=str, default="0,0.25,0.5,1")
+    parser.add_argument("--ablation_window_steps", type=int, default=50)
+    parser.add_argument("--ablation_target_passes", type=float, default=1.5)
+    parser.add_argument("--ablation_min_window_steps", type=int, default=8)
+    parser.add_argument("--ablation_max_window_steps", type=int, default=50)
+    parser.add_argument("--ablation_control_frac", type=float, default=0.2)
+    parser.add_argument("--ablation_log_path", type=str, default="")
+    parser.add_argument("--eval_main_override", type=str, default="")
+    parser.add_argument("--eval_main_budget", type=int, default=50_000)
+    parser.add_argument("--eval_main_skip", type=int, default=1_000_000)
+    parser.add_argument("--eval_aux_budget", type=int, default=1_500_000)
+    parser.add_argument("--eval_aux_skip", type=int, default=100_000)
+    parser.add_argument("--eval_aux_max_scanned", type=int, default=50_000)
+    parser.add_argument("--ablation_compute_ratios", type=_str_to_bool, nargs="?", const=True, default=True)
+    parser.add_argument("--ablation_wandb_analysis", type=_str_to_bool, nargs="?", const=True, default=True)
+    parser.add_argument("--ablation_analysis_min_rows", type=int, default=30)
+    parser.add_argument("--ablation_analysis_every_rows", type=int, default=5)
+    parser.add_argument("--ablation_analysis_step_df", type=int, default=2)
+
+
+def wrap_aux_dataset_with_ablation(aux_ds, args, eff_batch):
+    task_to_group = _load_group_map(args.ablation_group_map)
+    drop_rates = _parse_drop_rates(args.ablation_drop_rates)
+    groups = sorted(set(task_to_group.values()))
+    if not groups:
+        groups = ["unknown"]
+    ablation_unit = str(getattr(args, "ablation_unit", "group"))
+    if ablation_unit == "task":
+        units = sorted(task_to_group)
+    else:
+        units = groups
+    window_steps = _window_steps_for_budget(args, units, drop_rates, eff_batch)
+
+    aux_probability = _aux_probability(getattr(args, "aux_ratio", 0.0))
+    window_aux_examples = max(
+        1,
+        round(window_steps * int(eff_batch) * aux_probability),
+    )
+
+    tracker = MixAblationTracker(
+        task_to_group=task_to_group,
+        groups=groups,
+        units=units,
+        ablation_unit=ablation_unit,
+        drop_rates=drop_rates,
+        window_aux_examples=window_aux_examples,
+        window_steps=window_steps,
+        control_frac=float(args.ablation_control_frac),
+        seed=int(getattr(args, "seed", 0)),
+        aux_ratio=float(getattr(args, "aux_ratio", 0.0)),
+        log_path=args.ablation_log_path or "mix_ablation.jsonl",
+        wandb_analysis=(
+            bool(getattr(args, "ablation_wandb_analysis", True))
+            and bool(getattr(args, "ablation_compute_ratios", True))
+        ),
+        analysis_min_rows=int(getattr(args, "ablation_analysis_min_rows", 30)),
+        analysis_every_rows=int(getattr(args, "ablation_analysis_every_rows", 5)),
+        analysis_step_df=int(getattr(args, "ablation_analysis_step_df", 4)),
+    )
+
+    def gen():
+        rng = random.Random(int(getattr(args, "seed", 0)) + 1729)
+        for ex in aux_ds:
+            unit = tracker.unit_for_example(ex)
+            if tracker.should_drop(unit, rng):
+                continue
+            yield ex
+
+    return IterableDataset.from_generator(gen), tracker
+
+
+class MixAblationCallback(TrainerCallback):
+    def __init__(self, tracker):
+        self.tracker = tracker
+        self.previous_loss = None
+        self.last_logged_step = None
+        self.eval_rows = 0
+        self.analysis_warning_printed = False
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        logs = logs or {}
+        loss = _pick_main_loss(logs)
+        if loss is None or self.last_logged_step == state.global_step:
+            return
+
+        delta = None
+        if self.previous_loss is not None:
+            delta = loss - self.previous_loss
+        self.previous_loss = loss
+        self.last_logged_step = state.global_step
+        self.tracker.write_eval_row(
+            step=int(state.global_step),
+            eval_main_loss=loss,
+            eval_main_loss_delta=delta,
+        )
+        self.eval_rows += 1
+        self._maybe_log_wandb_analysis(step=int(state.global_step))
+
+    def _maybe_log_wandb_analysis(self, step):
+        if not self.tracker.wandb_analysis:
+            return
+        if self.eval_rows < self.tracker.analysis_min_rows:
+            return
+        every = max(1, self.tracker.analysis_every_rows)
+        if self.eval_rows % every:
+            return
+
+        try:
+            import wandb
+
+            if wandb.run is None:
+                return
+            from reasoning_core.training.analyze_mix_ablation import analyze_log_path
+
+            result = analyze_log_path(self.tracker.log_path, step_df=self.tracker.analysis_step_df)
+            metrics = {"mix_ablation/analysis_rows": int(self.eval_rows)}
+            for row in result.to_dict(orient="records"):
+                unit = _clean_metric_fragment(row["unit"])
+                metrics[f"mix_ablation/best_drop_rate/{unit}"] = float(row["best_drop_rate"])
+                metrics[f"mix_ablation/recommended_keep_ratio/{unit}"] = float(row["recommended_keep_ratio"])
+                metrics[f"mix_ablation/stderr/{unit}"] = float(row["stderr"])
+                metrics[f"mix_ablation/effect/{unit}"] = float(row["effect"])
+            wandb.log(metrics, step=step)
+        except Exception as exc:  # Keep training independent from analysis dependencies.
+            if not self.analysis_warning_printed:
+                print(f"mix_ablation W&B analysis disabled after error: {exc}")
+                self.analysis_warning_printed = True
+
+
+@dataclass
+class MixAblationTracker:
+    task_to_group: dict
+    groups: list
+    units: list
+    ablation_unit: str
+    drop_rates: list
+    window_aux_examples: int
+    window_steps: int
+    control_frac: float
+    seed: int
+    aux_ratio: float
+    log_path: str
+    wandb_analysis: bool = True
+    analysis_min_rows: int = 30
+    analysis_every_rows: int = 5
+    analysis_step_df: int = 4
+    lock: Lock = field(default_factory=Lock)
+    consumed_in_window: int = 0
+    target_unit: str | None = None
+    drop_rate: float = 0.0
+    kept: Counter = field(default_factory=Counter)
+    dropped: Counter = field(default_factory=Counter)
+    history: deque = field(default_factory=lambda: deque(maxlen=3))
+
+    def __post_init__(self):
+        self.rng = random.Random(self.seed + 104729)
+        self.schedule = []
+        self._refill_schedule()
+        self._advance_window()
+        path = Path(self.log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    def unit_for_example(self, ex):
+        task = _get_task(ex)
+        if task is None:
+            return "unknown"
+        task = str(task)
+        if self.ablation_unit == "task":
+            return task if task in self.task_to_group else "unknown"
+        return self.task_to_group.get(task, "unknown")
+
+    def should_drop(self, unit, rng):
+        with self.lock:
+            if self.consumed_in_window >= self.window_aux_examples:
+                self._advance_window()
+            self.consumed_in_window += 1
+            should_drop = (
+                self.target_unit is not None
+                and unit == self.target_unit
+                and rng.random() < self.drop_rate
+            )
+            if should_drop:
+                self.dropped[unit] += 1
+            else:
+                self.kept[unit] += 1
+            return should_drop
+
+    def write_eval_row(self, step, eval_main_loss, eval_main_loss_delta):
+        with self.lock:
+            target_group = self.group_for_unit(self.target_unit)
+            target_task = self.target_unit if self.ablation_unit == "task" else None
+            row = {
+                "step": step,
+                "target_unit": self.target_unit,
+                "target_unit_type": self.ablation_unit,
+                "target_group": target_group,
+                "target_task": target_task,
+                "drop_rate": self.drop_rate,
+                "eval_main_loss": eval_main_loss,
+                "eval_main_loss_delta": eval_main_loss_delta,
+                "aux_ratio": self.aux_ratio,
+                "window_aux_examples": self.window_aux_examples,
+                "window_steps": self.window_steps,
+            }
+            count_prefix = "task" if self.ablation_unit == "task" else "group"
+            for unit, count in sorted(self.kept.items()):
+                row[f"kept_{count_prefix}/{unit}"] = count
+                if self.ablation_unit == "group":
+                    row[f"kept/{unit}"] = count
+            for unit, count in sorted(self.dropped.items()):
+                row[f"dropped_{count_prefix}/{unit}"] = count
+                if self.ablation_unit == "group":
+                    row[f"dropped/{unit}"] = count
+            for lag, state in enumerate(reversed(list(self.history)[-3:]), start=1):
+                row[f"lag{lag}_target_unit"] = state["target_unit"]
+                row[f"lag{lag}_target_group"] = self.group_for_unit(state["target_unit"])
+                row[f"lag{lag}_target_task"] = state["target_unit"] if self.ablation_unit == "task" else None
+                row[f"lag{lag}_drop_rate"] = state["drop_rate"]
+
+            with Path(self.log_path).open("a", encoding="utf-8") as f:
+                f.write(json.dumps(row, sort_keys=True) + "\n")
+
+    def group_for_unit(self, unit):
+        if unit is None:
+            return None
+        if self.ablation_unit == "task":
+            return self.task_to_group.get(str(unit), "unknown")
+        return str(unit)
+
+    def _advance_window(self):
+        if self.consumed_in_window:
+            self.history.append({
+                "target_unit": self.target_unit,
+                "drop_rate": self.drop_rate,
+            })
+        if not self.schedule:
+            self._refill_schedule()
+        self.target_unit, self.drop_rate = self.schedule.pop()
+        self.consumed_in_window = 0
+        self.kept = Counter()
+        self.dropped = Counter()
+
+    def _refill_schedule(self):
+        treatments = [(unit, rate) for unit in self.units for rate in self.drop_rates]
+        controls = max(1, round(len(treatments) * self.control_frac / max(1e-9, 1 - self.control_frac)))
+        treatments.extend((None, 0.0) for _ in range(controls))
+        self.rng.shuffle(treatments)
+        self.schedule.extend(treatments)
+
+
+def _load_group_map(path):
+    path = Path(path)
+    if not path.exists():
+        repo_path = Path(__file__).resolve().parents[2] / path
+        if repo_path.exists():
+            path = repo_path
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if "task_to_group" in data:
+        return {str(k): str(v) for k, v in data["task_to_group"].items()}
+    if "groups" in data:
+        data = data["groups"]
+    task_to_group = {}
+    for group, tasks in data.items():
+        for task in tasks:
+            task_to_group[str(task)] = str(group)
+    return task_to_group
+
+
+def _parse_drop_rates(raw):
+    rates = [float(x.strip()) for x in str(raw).split(",") if x.strip()]
+    if not rates:
+        raise ValueError("--ablation_drop_rates must contain at least one numeric rate")
+    for rate in rates:
+        if rate < 0 or rate > 1:
+            raise ValueError(f"Invalid ablation drop rate {rate}; expected 0 <= rate <= 1")
+    return rates
+
+
+def _window_steps_for_budget(args, units, drop_rates, eff_batch):
+    explicit = int(getattr(args, "ablation_window_steps", 0) or 0)
+    min_steps = max(1, int(getattr(args, "ablation_min_window_steps", 8)))
+    max_steps = max(min_steps, int(getattr(args, "ablation_max_window_steps", explicit or 50)))
+    if explicit > 0 and explicit != 50:
+        return max(min_steps, min(max_steps, explicit))
+
+    max_length = int(getattr(args, "max_length", 1024))
+    token_budget = int(getattr(args, "token_budget", 0))
+    aux_ratio = float(getattr(args, "aux_ratio", 0.0))
+    total_steps = max(1, int(token_budget * (1 + aux_ratio) // max(1, max_length * eff_batch)))
+    cells = max(1, len(units) * len(drop_rates))
+    controls = max(1, round(cells * float(getattr(args, "ablation_control_frac", 0.2)) / max(1e-9, 1 - float(getattr(args, "ablation_control_frac", 0.2)))))
+    target_windows = max(1.0, (cells + controls) * float(getattr(args, "ablation_target_passes", 1.5)))
+    return max(min_steps, min(max_steps, round(total_steps / target_windows)))
+
+
+def _aux_probability(aux_ratio):
+    aux_ratio = float(aux_ratio)
+    if aux_ratio <= 0:
+        return 0.0
+    return aux_ratio / (1.0 + aux_ratio)
+
+
+def _get_task(ex):
+    if isinstance(ex, dict):
+        for key in ("task", "_task", "source_task"):
+            value = ex.get(key)
+            if value not in (None, ""):
+                return value
+    return None
+
+
+def _pick_main_loss(metrics):
+    for key in ("eval_main_loss", "eval/main_loss", "final_main_loss", "final/main_loss"):
+        if key in metrics:
+            return float(metrics[key])
+    return None
+
+
+def _clean_metric_fragment(value):
+    return str(value).replace("/", "_").replace(" ", "_")
+
+
+def _str_to_bool(value):
+    if isinstance(value, bool):
+        return value
+    value = str(value).lower()
+    if value in ("1", "true", "t", "yes", "y", "on"):
+        return True
+    if value in ("0", "false", "f", "no", "n", "off"):
+        return False
+    raise argparse.ArgumentTypeError(f"Expected boolean value, got {value!r}")

--- a/reasoning_core/training/run_sft.py
+++ b/reasoning_core/training/run_sft.py
@@ -37,6 +37,7 @@ from prodigyplus.prodigy_plus_schedulefree import ProdigyPlusScheduleFree
 from trl import SFTConfig, SFTTrainer
 from tabulate import tabulate
 from reasoning_core.downstream_eval import run_harness, run_platinum
+from reasoning_core.training.mix_ablation import MixAblationCallback, add_mix_ablation_args, wrap_aux_dataset_with_ablation
 import socket, threading, time, atexit
 
 disable_caching()
@@ -65,6 +66,7 @@ parser.add_argument('--iterable_mode', type=ast.literal_eval, default=True)
 parser.add_argument('--title', type=str, default='')
 parser.add_argument('--seed', type=int, default=0)
 parser.add_argument('--n_eval', type=int, default=10)
+add_mix_ablation_args(parser)
 
 DATA_MAP = {
     "fw": "HuggingFaceFW/fineweb-edu",
@@ -224,10 +226,12 @@ def get_formatter(data_key):
     def fmt(x):
         prefix = SPECIAL + "\n" if SPECIAL and data_key == "rc" else ""
         answer = x.get("answer")
-        return {
+        ex = {
             "prompt": prefix + f"Q: {x['prompt']}\nA:",
             "completion": " "+answer + tokenizer.eos_token,
         }
+        ex.update({k: x[k] for k in ("task", "level") if x.get(k) not in (None, "")})
+        return ex
     return fmt
 
 # --- Materialized loader (original behavior; also used for evals) ---
@@ -291,6 +295,27 @@ def load_exact_tokens_iterable(key, budget, max_len=None, chars_per_token=4.0, c
     return ds
 
 
+# --- 🔄 Training ---
+_total_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
+_model_params = sum(p.numel() for p in model.parameters()) / 1e6
+
+available_memory_factor = max(1, min(16, round(
+    2 * (_model_params / 68) * (24 / _total_gb)
+)))
+
+observed_memory_peak = 0.90
+target_memory_peak = 0.90
+
+available_memory_factor = max(1, min(16, round(
+    available_memory_factor * observed_memory_peak / target_memory_peak
+)))
+
+TARGET_EFFECTIVE_BS = 64
+per_device_bs = 1 << ((16 // available_memory_factor).bit_length() - 1)  # largest pow2 ≤ 16//factor
+grad_accum    = TARGET_EFFECTIVE_BS // per_device_bs
+eff_batch = per_device_bs * grad_accum
+
+
 # --- 🧪 Experiment Setup ---
 
 def clean_metric_key(x):
@@ -318,16 +343,25 @@ def load_eval_split(key, budget=250_000, skip=100_000, group_by=("task", "level"
     return result
 
 # Evals: always materialized (tiny, trainer needs __len__)
-eval_main, _ = load_exact_tokens_materialized(args.main_data, 50_000, stream_skip=1_000_000, max_len=args.max_length)
-eval_splits = load_eval_split(args.aux_data, budget=1_500_000, skip=100_000, max_groups=200, max_examples_per_group=32, min_examples_per_group=24)
+eval_key = args.eval_main_override or args.main_data
+eval_main, _ = load_exact_tokens_materialized(
+    eval_key, args.eval_main_budget, stream_skip=args.eval_main_skip, max_len=args.max_length)
+eval_splits = load_eval_split(
+    args.aux_data, budget=args.eval_aux_budget, skip=args.eval_aux_skip,
+    max_groups=200, max_examples_per_group=32, min_examples_per_group=24,
+    max_scanned=args.eval_aux_max_scanned)
 evals = {"main": eval_main, **{f"aux_tl/{k}": v for k, v in eval_splits.items()}}
 
 
 aux_budget = int(args.token_budget * args.aux_ratio)
+ablation_tracker = None
 
 if args.iterable_mode:
     s1_main_ds = load_exact_tokens_iterable(args.main_data, args.token_budget, max_len=args.max_length)
     s1_aux_ds = load_exact_tokens_iterable(args.aux_data, aux_budget, max_len=args.max_length, cycle=True)
+
+    if args.mix_ablation and s1_aux_ds is not None:
+        s1_aux_ds, ablation_tracker = wrap_aux_dataset_with_ablation(s1_aux_ds, args=args, eff_batch=eff_batch)
 
     parts = [d for d in [s1_main_ds, s1_aux_ds] if d is not None]
     if len(parts) == 2:
@@ -341,6 +375,7 @@ if args.iterable_mode:
 
     s2_main_ds = None  # disabled in iterable mode
 else:
+    if args.mix_ablation: print("⚠️  mix_ablation requires iterable_mode=True; ablation disabled.")
     s1_main_ds, main_rows_consumed = load_exact_tokens_materialized(
         args.main_data, args.token_budget, stream_skip=0, max_len=args.max_length)
     s1_aux_ds, _ = load_exact_tokens_materialized(
@@ -489,26 +524,6 @@ class DownstreamEvalCallback(TrainerCallback):
             self.optimizer.train()
 
 
-# --- 🔄 Training ---
-_total_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
-_model_params = sum(p.numel() for p in model.parameters()) / 1e6
-
-available_memory_factor = max(1, min(16, round(
-    2 * (_model_params / 68) * (24 / _total_gb)
-)))
-
-observed_memory_peak = 0.90
-target_memory_peak = 0.90
-
-available_memory_factor = max(1, min(16, round(
-    available_memory_factor * observed_memory_peak / target_memory_peak
-)))
-
-TARGET_EFFECTIVE_BS = 64
-per_device_bs = 1 << ((16 // available_memory_factor).bit_length() - 1)  # largest pow2 ≤ 16//factor
-grad_accum    = TARGET_EFFECTIVE_BS // per_device_bs
-
-
 common_args = dict(
     learning_rate=1.0, per_device_train_batch_size=per_device_bs,
     gradient_accumulation_steps=grad_accum, max_grad_norm=0.0, #grad clip is  handled by prodigy  
@@ -520,7 +535,6 @@ common_args = dict(
 
 # Iterable mode: compute max_steps from token budget (trainer can't infer from a stream)
 if args.iterable_mode:
-    eff_batch = per_device_bs * grad_accum
     total_tokens = args.token_budget * (1 + args.aux_ratio)
     max_steps_s1 = max(1, int(total_tokens // (args.max_length * eff_batch)))
     print(f"📐 max_steps (stage1) = {max_steps_s1}  (eff_batch={eff_batch}, seq_len={args.max_length})")
@@ -568,15 +582,16 @@ def run_stage(ds, stage_name, epochs=1.0, max_steps=-1, restart=False):
 
 
 
+    callbacks = [ScheduleFreeModeCallback(optimizer), DownstreamEvalCallback(model, tokenizer, optimizer, n=args.n_eval)]
+    if ablation_tracker is not None:
+        callbacks.append(MixAblationCallback(ablation_tracker))
+
     trainer = SFTTrainer(
         model=model, processing_class=tokenizer,
         args=SFTConfig(**sft_kwargs),
         train_dataset=ds, eval_dataset=evals,
         optimizers=(optimizer, scheduler),
-        callbacks=[
-            ScheduleFreeModeCallback(optimizer),
-            DownstreamEvalCallback(model, tokenizer, optimizer, n=args.n_eval),
-        ],
+        callbacks=callbacks,
     )
 
     trainer.callback_handler.callbacks.insert(


### PR DESCRIPTION
Adds RC taskmix ablation for fixed-aux-ratio training.

- wraps the aux iterable stream to drop task/group examples and replace them with later RC examples
- logs local JSONL rows plus optional W&B ratio estimates
- adds a small offline analyzer and default task group map
- keeps run_sft.py to orchestration hooks only

Validation:
- PYTHONPATH=$PWD python -m py_compile reasoning_core/training/mix_ablation.py reasoning_core/training/analyze_mix_ablation.py reasoning_core/training/run_sft.py