### PR TITLE
Add music reasoning task generators

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
+## Project Documentation
+
+* [Music reasoning specification](music_reasoning_specification.md)
+
 ## Commands
 
 * `mkdocs new [dir-name]` - Create a new project.

--- a/docs/music_reasoning_specification.md
+++ b/docs/music_reasoning_specification.md
@@ -1,0 +1,565 @@
+# Music Reasoning Tasks for Reasoning Core
+
+This document is a working specification. Implemented behavior is authoritative where this draft and the code disagree.
+
+This document proposes music reasoning task families for Reasoning Core. It is intentionally written in the style of the existing task implementations in `reasoning_core/tasks/` and the rules in `TASK_AUTHORING_GUIDE.md`.
+
+In Reasoning Core, `Config.set_level(i)` resets the config and applies `update(c)` `i` times. Existing tasks such as equation systems, graph reasoning, constraint satisfaction, grammar tasks, arithmetic, and sequential induction mostly follow that pattern. They do not define a fixed curriculum where level 0 is task A and level 5 is task F.
+
+The music tasks below therefore use **modes** for task variants and **knobs** for difficulty. A mode may be sampled randomly or fixed by config.
+
+---
+
+## Metadata Pattern
+
+Implemented music families store task-owned metadata in this pattern:
+
+- `mode`: the resolved concrete operation, such as `interval_naming`, `pitch_count`, `chord_quality`, or `roman_numeral_from_chord`;
+- `prompt`: the exact generated prompt text returned by `Task.prompt()`;
+- `answer_kind`: the answer-normalization family used by `score_answer`, such as `note`, `interval`, `integer`, `yes_no`, `roman`, `note_sequence`, or `label`;
+- `cot`: programmatic reasoning trace generated from the same symbolic operations used to compute the answer;
+- task-specific hidden state, such as source notes, interval qualities/numbers, chord notes, key labels, Roman figures, notation style, and answer notation.
+
+Reasoning Core already adds framework metadata such as `_task`, `_level`, and `_config` in `Task.generate_example()`, so task metadata does not duplicate the task family name. The canonical answer is stored in `Problem.answer`; task-specific metadata stores enough hidden state to reconstruct or audit that answer where useful.
+
+Difficulty should be represented in `_config`, not only in prose. For example:
+
+```python
+def update(self, c=1):
+    self.context_len += c
+    self.max_accidental += 0.25 * c
+    self.n_candidates += c
+```
+
+This means level 0 and level 5 are the same task, but level 5 has larger or less forgiving instances.
+
+---
+
+## Difficulty Semantics
+
+In implementation, there should be no hand-authored table like "level 0 does interval naming, level 1 does inversion, level 2 does enharmonic spelling." That pattern changes the task with level.
+
+Use this interpretation instead:
+
+- level 0 is the base config;
+- level `k` is the result of applying `update(c)` `k` times;
+- `update(c)` changes numeric knobs monotonically;
+- modes are sampled from config or fixed by config, not unlocked by level;
+- larger levels may enlarge the structural domain, such as more voices, more constraints, a larger grammar, or more candidate keys, while preserving the same answer schema.
+
+Each task config should expose a `mode: str = "any"` field. If `mode == "any"`, `generate()` samples one concrete mode from the family; otherwise it uses the requested fixed mode. The resolved concrete mode should always be stored in `metadata["mode"]`.
+
+**Config sketch type convention:** each config sketch should be a dataclass subclass of `Config`; otherwise subclass fields are not visible to `Config.__post_init__()` and stochastic rounding will not apply. Count-like knobs should stay annotated as `int` even when `update(c)` adds fractional increments such as `0.5 * c` or `1.5 * c`. This follows Reasoning Core's `Config` behavior: `int` fields are tracked internally as unrounded floats during updates, so the fractional part is not lost, and then stochastically rounded to integers on read. For example, `score_len: int = 1` followed by `self.score_len += 0.5 * c` has an internal value of `1.5` after one level update. Use `float` only for genuinely continuous knobs such as probabilities, weights, thresholds, or soft sampling parameters. The sketches assume `from dataclasses import dataclass`.
+
+Level 5 should be difficult because the generated instance is larger, noisier, more constrained, or less forgiving.
+
+---
+
+## Low-Entropy Music Domains
+
+Music has many small finite domains: 12 pitch classes, 24 common major/minor key signatures, a small set of diatonic triads, and a limited set of common cadences. Do not rely only on transposition for variety.
+
+Use variety from combinations of dimensions:
+
+- spelling: sharp, flat, double-sharp, double-flat, naturalized notes;
+- register: simple vs compound intervals, octave displacement, close/open voicing;
+- representation: note names, scale degrees, solfege, ABC notation, chord symbols, Roman numerals, tables, JSON;
+- query form: classify, construct, validate, repair, compare, count, complete, infer;
+- context size: one note, interval, chord, progression, phrase, multi-voice excerpt;
+- convention: strict written spelling vs pitch-class equivalence, global vs local key, functional labels vs Roman numerals;
+- controlled corruption: wrong accidental, wrong inversion, wrong local key, wrong resolution, wrong clef, wrong duration, wrong field.
+
+---
+
+## MusicTheoryBench (MTB) Coverage
+
+MTB contains 98 reasoning rows. The task families below are designed to cover them.
+
+Approximate multi-label coverage of the 98 MTB reasoning rows:
+
+| Task family | MTB reasoning coverage signal |
+|---|---|
+| `pitch_interval_reasoning` | 40 |
+| `chord_roman_reasoning` | 25 |
+| `key_scale_mode_reasoning` | 48 |
+| `rhythm_meter_reasoning` | 2 |
+| `harmony_progression_reasoning` | 7 |
+| `voice_leading_reasoning` | 4 |
+| `formal_music_transformations` | 5 |
+| `analysis_representation_reasoning` | 15 |
+
+Rows can belong to several families. For example, an ABC score can be a representation of an interval, chord, mode, or voice-leading question.
+
+---
+
+# Task Families in Implementation Order
+
+These families are ordered for implementation: start with compact, strongly verifiable domains, then move toward convention-heavy and schema-heavy generators. Each family lists modes in a single table.
+
+## 1. `pitch_interval_reasoning`
+
+**Stable task principle:** Given pitch, interval, key, or short notated material plus a requested query field, compute the canonical pitch/interval answer.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `interval_naming` | `Name the interval from F#3 to A4. Notes are written in scientific pitch notation. The answer is one interval name, including compound/simple size as written.` | `minor tenth` |
+| `interval_arithmetic` | `Start with a major tenth, then reduce to a simple interval and invert it, then add a minor third. The answer is one interval name.` | `major seventh` |
+| `pitch_count` | `Under pitch-class equivalence, how many distinct pitch classes are in C4, C5, B#3, Db4, C#5, Ebb4? Notes are written in scientific pitch notation. The answer is one integer.` | `3` |
+| `interval_classification` | `In C harmonic minor, classify the ascending note-to-note relation Eb-B using one of these labels: diatonic consonance, diatonic dissonance, chromatic alteration. The answer is one label from that list.` | `diatonic dissonance` |
+| `enharmonic_interval_comparison` | `Are C#4-E4 and Db4-Fb4 enharmonically equivalent intervals? Notes are written in scientific pitch notation. The answer is exactly 'yes' or 'no'.` | `yes` |
+| `instrument_transposition` | `A B-flat clarinet part writes D5. What sounding pitch is produced? Notes are written in scientific pitch notation. The answer is one note name in scientific pitch notation.` | `C5` |
+| `interval_construction` | `Build a minor third below E. Notes are written in scientific pitch notation. The answer is one note name without octave in scientific pitch notation.` | `C#` |
+| `transposition_chain` | `Transpose F# up a minor third, down a perfect fifth, then up a major second. Notes are written in scientific pitch notation. The answer is one note name without octave in scientific pitch notation.` | `E` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `chain_len` | Shared length knob for chain-like pitch/interval tasks. | `interval_arithmetic`, `transposition_chain` | one operation | longer composed operation chains such as add/subtract, reduce-then-invert, and transpose |
+| `max_accidental` | Accidental/quality complexity used when sampling notes and interval qualities; constructed results may still require the spelling implied by the operation. | all | sampled notes use naturals, sharps, flats; simple interval qualities | sample double accidentals, double-augmented/double-diminished intervals, and stricter spelling traps |
+| `key_complexity` | Maximum number of sharps/flats in analytical key signatures. | `interval_classification` | common keys up to two sharps/flats | expands to all conventional major/minor keys |
+| `max_interval_number` | Largest diatonic interval number allowed in generated intervals. | `interval_naming`, `interval_arithmetic`, `enharmonic_interval_comparison`, `interval_construction`, `transposition_chain` | simple intervals | compound intervals and wider registers |
+| `n_candidates` | Number of note items in count-style instances. | `pitch_count` | short note list | longer note lists with more duplicates and distractors |
+| `p_abc` | Probability of rendering prompt notes in ABC notation instead of scientific pitch notation; note-answer modes use the matching answer notation policy. 70% of ABC cases use compact ABC note tokens and 30% use full ABC score fragments with randomly sampled common `L:`, `M:`, and `K:` headers. Full ABC interval pairs are rendered as bracketed harmonic intervals, and full-ABC note-answer modes ask for compact ABC answers with explicit accidentals. | `interval_naming`, `pitch_count`, `enharmonic_interval_comparison`, `instrument_transposition`, `interval_construction`, `transposition_chain` | SPN note names | more compact and full-score ABC input notation, plus compact ABC answers where applicable |
+
+**Config sketch**
+
+```python
+@dataclass
+class PitchIntervalConfig(Config):
+    mode: str = "any"
+    chain_len: int = 1
+    max_interval_number: int = 8
+    n_candidates: int = 4
+    max_accidental: int = 1
+    key_complexity: int = 2
+    p_abc: float = 0.20
+    max_tries: int = 256
+
+    def update(self, c=1):
+        self.chain_len += 0.6 * c
+        self.max_interval_number = min(20, self.max_interval_number + 1.5 * c)
+        self.n_candidates += c
+        self.max_accidental = min(2, self.max_accidental + 0.2 * c)
+        self.key_complexity = min(7, self.key_complexity + 1 * c)
+        self.p_abc = min(0.50, self.p_abc + 0.06 * c)
+```
+
+**Tools:** project-owned pitch/interval spelling solver as source of truth; custom rule tables for transposing instruments.
+
+---
+
+## 2. `chord_roman_reasoning`
+
+**Stable task principle:** Given a chord object and optional key/context, compute the requested canonical chord/Roman-numeral field.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `chord_quality` | `Identify the quality of Bb-C#-E-G. Use one of these labels: major triad, minor triad, diminished triad, augmented triad, major seventh, dominant seventh, minor seventh, half-diminished seventh, fully diminished seventh, minor-major seventh, augmented-major seventh. The answer is one label from that list.` | `fully diminished seventh` |
+| `inversion` | `Treat the chord in this ABC score fragment:\nL:1/16\nM:4/4\nK:Eb\n  [^A=BD^F] |] %1 as the chord tones and "^F" as the bass note. Interpret the ABC score using its key signature. The answer is one inversion label followed by figured bass.` | `second inversion 4/3` |
+| `open_close_voicing` | `Classify the voicing "C"-"G"-"e". Notes are written in compact ABC notation. Choose from: close voicing, open voicing. The answer is one label from that list.` | `open voicing` |
+| `enharmonic_chord_equivalence` | `Compare "C"-"^E"-"G"-"B" and "^B"-"F"-"__A"-"_C": are they enharmonically equivalent pitch-class chords? Notes are written in compact ABC notation. Answer exactly 'yes' or 'no'.` | `yes` |
+| `chromatic_chord_label` | `In C major, what chromatic label fits C-Ab-F# over Ab? Select exactly one label from this list: French augmented sixth, Italian augmented sixth, German augmented sixth, Swiss augmented sixth, Neapolitan sixth.` | `Italian augmented sixth` |
+| `chord_membership` | `Do all tones of Cb-F-Ab belong to Eb natural minor? Give one answer, either 'yes' or 'no'.` | `yes` |
+| `roman_numeral_from_chord` | `In D minor, analyze the chord in this ABC score fragment:\nL:1/8\nM:6/8\nK:Fm\n  [=A=D=B^F] |] %1 with "^F" in the bass. Interpret the ABC score using its key signature. Answer with one compact Roman numeral and closed-up figured bass.` | `vi43` |
+| `chord_from_roman_numeral` | `Which chord tones does vi43 produce in D minor? The expected answer is a bass-upward note sequence in compact ABC notation, with any accidental made explicit, separated by hyphens.` | `^F-=A-=B-=D` |
+
+Prompt wording is intentionally varied in every mode. Chord-tone prompts may be written in scientific pitch notation, compact ABC notation, or full ABC score fragments. Full ABC score prompts use bracketed chord events and include a key-signature interpretation instruction; their CoTs resolve any implicit ABC accidentals before applying the chord/Roman rule. Modes with unordered chord-tone collections usually omit octaves, while voicing tasks always include octaves and several comparison/context modes sample both octave-bearing and octave-free forms. `chord_from_roman_numeral` has no input chord to render; instead, its requested answer notation follows the sampled style, with full-ABC style asking for compact ABC answer tokens with explicit accidentals. Roman-numeral modes include diatonic triads/seventh chords plus secondary dominant and secondary leading-tone functions to common non-tonic scale-degree targets. Where chord-tone order and answer-choice order are not musically significant, the generator also samples those orders to increase prompt diversity while keeping the same canonical answer semantics.
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `p_seventh` | Probability of sampling a seventh chord instead of a triad in modes that can use either size. | `chord_quality`, `inversion`, `open_close_voicing`, `enharmonic_chord_equivalence`, `chord_membership`, `roman_numeral_from_chord`, `chord_from_roman_numeral` | 30% seventh chords, 70% triads | +0.06 per level, capped at 60% seventh chords |
+| `max_accidental` | Accidental complexity in generated chord tones, roots, chromatic labels, membership distractors, enharmonic respellings, and Roman-derived spellings. | all modes | simple spelling | chromatic and enharmonic spellings |
+| `key_complexity` | Maximum number of sharps/flats in analytical key signatures. | `chord_membership`, `chromatic_chord_label`, `roman_numeral_from_chord`, `chord_from_roman_numeral` | common keys up to two sharps/flats | expands to all conventional major/minor keys |
+| `p_secondary` | Probability of sampling secondary-dominant or secondary-leading-tone Roman material where the mode allows it. | `roman_numeral_from_chord`, `chord_from_roman_numeral` | mostly diatonic Roman numerals | more secondary/applied Roman numerals |
+| `p_abc` | Probability of rendering chord-tone prompts in ABC notation where a mode has input chord tones, or note-sequence answers in compact ABC notation for `chord_from_roman_numeral`. ABC prompt cases split into 70% compact ABC note tokens and 30% full ABC score fragments with sampled common `L:`, `M:`, and `K:` headers. | all modes | mostly scientific pitch notation | more compact ABC and full ABC score prompts or compact ABC answer sequences |
+
+**Config sketch**
+
+```python
+@dataclass
+class ChordRomanConfig(Config):
+    mode: str = "any"
+    p_seventh: float = 0.30
+    max_accidental: int = 1
+    key_complexity: int = 2
+    p_secondary: float = 0.10
+    p_abc: float = 0.20
+    max_tries: int = 256
+
+    def update(self, c=1):
+        self.p_seventh = min(0.60, self.p_seventh + 0.06 * c)
+        self.max_accidental = min(2, self.max_accidental + 0.2 * c)
+        self.key_complexity = min(7, self.key_complexity + 1 * c)
+        self.p_secondary = min(0.70, self.p_secondary + 0.08 * c)
+        self.p_abc = min(0.50, self.p_abc + 0.06 * c)
+```
+
+**Tools:** `music21.chord`, `music21.roman`, `music21.key`; custom convention layer for accepted Roman-numeral spelling and chromatic-function labels.
+
+---
+
+## 3. `key_scale_mode_reasoning`
+
+**Stable task principle:** Given a key, scale, mode, or generated modal rule system plus a requested query field, compute canonical membership, key signature, scale degree, tonic, mode label, or note collection.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `key_membership` | `Is E# in F# harmonic minor? The answer is exactly 'yes' or 'no'.` | `yes` |
+| `stable_degree_set` | `In F# minor, list the stable scale degrees 1, 3, and 5 as note names. The answer is comma-separated note names ascending.` | `F#, A, C#` |
+| `minor_scale_membership` | `Is D# in ascending E melodic minor? The answer is exactly 'yes' or 'no'.` | `yes` |
+| `chromatic_scale_spelling` | `In a descending chromatic scale from D to C, what note lies between D and C? The answer is one note name.` | `Db` |
+| `pentatonic_mode_collection` | `A Gong pentatonic mode on F# uses degrees 1, 2, 3, 5, 6. List its notes. The answer is comma-separated note names.` | `F#, G#, A#, C#, D#` |
+| `custom_mode_degree` | `A supplied Ya-yue rule says Qing-jue is two semitones above Jue. If Jue is E, what is Qing-jue? The answer is one note name.` | `F#` |
+| `messiaen_common_tones` | `Mode V Form 3 of Messiaen's finite transposition system has pitch classes {C, D, E, F#, G#, A#}; D Phrygian has {D, Eb, F, G, A, Bb, C}. How many pitch classes are common? The answer is one integer.` | `3` |
+| `pythagorean_interval_term` | `In the supplied Pythagorean tuning table, limma is the diatonic semitone and apotome is the chromatic semitone. Which term names the chromatic semitone? The answer is one term.` | `apotome` |
+| `generated_modal_system` | `Mode M on F starts with semitone steps 2, 1, 3, 2. List the first five notes including the tonic. The answer is comma-separated note names.` | `F, G, Ab, B, C#` |
+| `scale_degree_constraints` | `Find the major key where E is scale degree 3, F is scale degree 4, and B is scale degree 7. The answer is one tonic note name.` | `C` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `n_constraints` | Number of clues or constraints about notes, degrees, membership, or exclusions. | `key_membership`, `minor_scale_membership`, `scale_degree_constraints` | one note or degree | multiple note, degree, and exclusion constraints |
+| `n_candidates` | Number of keys, scales, modes, or collections to compare or enumerate. | `key_membership`, `minor_scale_membership`, `messiaen_common_tones`, `scale_degree_constraints` | direct answer | possible-key lists, reject-one-option, count answers |
+| `system_pool_size` | Number of scale or mode systems available to the sampler. | `custom_mode_degree`, `messiaen_common_tones`, `pythagorean_interval_term`, `generated_modal_system` | common major/minor | more generated mode systems from a fixed pool |
+| `max_accidental` | Spelling complexity allowed in tonics and scale members. | all except `pythagorean_interval_term` | simple spelling | double accidentals and strict names |
+| `collection_size` | Number of notes or degrees in the queried/generated collection. | `stable_degree_set`, `pentatonic_mode_collection`, `messiaen_common_tones`, `generated_modal_system` | small note set | larger modal or scale collections |
+| `p_custom_system` | Probability of using a nonstandard or generated modal/tuning rule table. | `custom_mode_degree`, `messiaen_common_tones`, `pythagorean_interval_term`, `generated_modal_system` | rare | more custom modal/tuning rule tables |
+
+**Config sketch**
+
+```python
+@dataclass
+class KeyScaleModeConfig(Config):
+    mode: str = "any"
+    n_constraints: int = 1
+    n_candidates: int = 1
+    collection_size: int = 3
+    system_pool_size: int = 2
+    max_accidental: int = 1
+    p_custom_system: float = 0.15
+
+    def update(self, c=1):
+        self.n_constraints += 0.7 * c
+        self.n_candidates += 0.8 * c
+        self.collection_size += 0.8 * c
+        self.system_pool_size += 0.5 * c
+        self.max_accidental += 0.2 * c
+        self.p_custom_system = min(0.75, self.p_custom_system + 0.07 * c)
+```
+
+**Tools:** `music21.key`, `music21.scale`, `music21.pitch`; generated rule tables for non-Western or artificial systems; `numpy`/`sympy` for pitch-class sets; optional `z3-solver` for unique-solution constraints.
+
+---
+
+## 4. `rhythm_meter_reasoning`
+
+**Stable task principle:** Given meter and rhythmic events, compute or validate a canonical rhythmic property.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `meter_classification` | `Classify 9/8 as simple or compound and duple, triple, or quadruple. The answer is two words.` | `compound triple` |
+| `compound_time_signature` | `Which common compound quadruple time signature has twelve eighth-note subdivisions? The answer is one time signature.` | `12/8` |
+| `duration_sum` | `Dotted eighth note plus sixteenth note plus quarter note equals what duration? The answer is one duration name.` | `half note` |
+| `measure_completion` | `In 6/8, dotted quarter + blank completes the measure. What is blank? The answer is one duration name.` | `dotted quarter note` |
+| `tuplet_reasoning` | `Three equal notes fill the time of one quarter note. What is each note called? The answer is one duration name.` | `triplet eighth note` |
+| `rhythmic_validity` | `Does dotted quarter + eighth + quarter exactly fill one 3/4 measure? The answer is exactly 'yes' or 'no'.` | `yes` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `n_events` | Number of rhythmic events or durations in the instance. | `duration_sum`, `measure_completion`, `rhythmic_validity` | few durations | longer rhythmic strings |
+| `n_measures` | Number of measures or metrical spans to validate or complete. | `measure_completion`, `rhythmic_validity` | one measure | multi-measure validation |
+| `n_missing` | Number of blanks, corruptions, or unknown durations to solve. | `measure_completion` | zero or one | multiple blanks or repairs |
+| `max_group_parts` | Maximum number of subdivisions or grouped parts in a beat/measure. | `meter_classification`, `compound_time_signature`, `tuplet_reasoning` | simple grouping | irregular grouping |
+| `p_tuplet` | Probability of using tuplet durations. | `duration_sum`, `measure_completion`, `tuplet_reasoning`, `rhythmic_validity` | low | more tuplets |
+| `p_tie_or_dot` | Probability of using tied or dotted durations. | `duration_sum`, `measure_completion`, `rhythmic_validity` | low | more dots and ties |
+
+**Config sketch**
+
+```python
+@dataclass
+class RhythmMeterConfig(Config):
+    mode: str = "any"
+    n_events: int = 3
+    n_measures: int = 1
+    n_missing: int = 1
+    max_group_parts: int = 2
+    p_tuplet: float = 0.05
+    p_tie_or_dot: float = 0.10
+
+    def update(self, c=1):
+        self.n_events += c
+        self.n_measures += 0.3 * c
+        self.n_missing += 0.2 * c
+        self.max_group_parts += 0.3 * c
+        self.p_tuplet = min(0.50, self.p_tuplet + 0.05 * c)
+        self.p_tie_or_dot = min(0.65, self.p_tie_or_dot + 0.06 * c)
+```
+
+**Tools:** exact `fractions.Fraction` arithmetic as source of truth; `music21.duration` and `music21.meter` for notation semantics; optional `z3-solver` for constrained missing-duration generation.
+
+---
+
+## 5. `harmony_progression_reasoning`
+
+**Stable task principle:** Given a structured harmonic progression and a requested query field, compute the canonical harmonic relation, function sequence, cadence, local key, modulation decision, or continuation set.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `modulation_type` | `Under the rule "modulation needs a cadence in the new key", C: I-V/V-V-I is what? The answer is one label: 'tonicization only', 'modulation', or 'neither'.` | `tonicization only` |
+| `key_distance` | `From C major to E major, classify the relationship using one of these labels: closely related, distant. The answer is one label from that list.` | `distant` |
+| `enharmonic_modulation` | `A German augmented sixth in C is respelled as V7 of Db. What modulation type is this? The answer is one modulation label, e.g. 'pivot-chord modulation'.` | `enharmonic modulation` |
+| `pivot_chord_function` | `The chord D-F#-A is V/V in C major and what Roman numeral in G major? The answer is one Roman numeral.` | `V` |
+| `modal_modulation` | `A passage changes from C Ionian to C Dorian while keeping tonic C. The answer is one modulation label.` | `modal modulation` |
+| `harmonic_function` | `In C major, what function does D-F-A-C with F in the bass have? Choose from: tonic, predominant, dominant. The answer is one label from that list.` | `predominant` |
+| `cadence_identification` | `At a phrase ending in C major, V-vi forms what cadence type? Choose from: authentic cadence, half cadence, plagal cadence, deceptive cadence. The answer is one label from that list.` | `deceptive cadence` |
+| `local_key_tonicization` | `In C major, V/V targets which local tonic? The answer is one note name.` | `G` |
+| `syntax_validity` | `In a simple T-PD-D-T grammar, can a predominant normally follow a dominant without tonic resolution? The answer is exactly 'yes' or 'no'.` | `no` |
+| `functional_parse` | `Parse C: I-vi-ii6-V7-I as functions using T, PD, and D. The answer is space-separated function labels.` | `T T PD D T` |
+| `harmonic_continuation` | `After C: Ger+6, which function normally follows: tonic, predominant, or dominant? The answer is one function label.` | `dominant` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `progression_len` | Number of chord or Roman-numeral events in the progression. | all except `key_distance` | 2-3 chords | longer phrases |
+| `n_local_regions` | Number of distinct local key regions or tonic contexts. | `modulation_type`, `enharmonic_modulation`, `pivot_chord_function`, `modal_modulation`, `local_key_tonicization` | one key | tonicizations and modulations |
+| `grammar_depth` | Depth of functional or harmonic grammar expansion. | `harmonic_function`, `cadence_identification`, `syntax_validity`, `functional_parse`, `harmonic_continuation` | simple T-D-T | expansions, ambiguity, applied functions |
+| `n_candidates` | Number of functions, parses, labels, or continuations to compare. | all | direct label | all-valid continuations or parses |
+| `p_ambiguity` | Probability of convention-dependent or multiply plausible cases. | all | low | more convention-dependent cases |
+| `p_chromatic` | Probability of chromatic harmony, mixture, pivots, or enharmonic material. | `modulation_type`, `enharmonic_modulation`, `pivot_chord_function`, `local_key_tonicization`, `harmonic_continuation` | low | more mixture, pivots, enharmonic cases |
+
+**Config sketch**
+
+```python
+@dataclass
+class HarmonyProgressionConfig(Config):
+    mode: str = "any"
+    progression_len: int = 3
+    n_local_regions: int = 1
+    grammar_depth: int = 2
+    n_candidates: int = 1
+    p_ambiguity: float = 0.05
+    p_chromatic: float = 0.10
+
+    def update(self, c=1):
+        self.progression_len += c
+        self.n_local_regions += 0.3 * c
+        self.grammar_depth += 0.6 * c
+        self.n_candidates += 0.7 * c
+        self.p_ambiguity = min(0.60, self.p_ambiguity + 0.06 * c)
+        self.p_chromatic = min(0.70, self.p_chromatic + 0.08 * c)
+```
+
+**Tools:** `music21.roman` and `music21.key` for canonicalization; custom function/cadence/modulation rule tables as source of truth; optional `networkx` for key-relation graphs; optional grammar tools for parse generation.
+
+---
+
+## 6. `voice_leading_reasoning`
+
+**Stable task principle:** Given one or more voice-leading transitions, validate them or return the canonical set of violations.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `leading_tone_resolution` | `In a C major V-I cadence, soprano B over G-B-D resolves to which soprano note in the I chord? The answer is one note name.` | `C` |
+| `chordal_seventh_resolution` | `In a C major V7-I cadence, alto F is the chordal seventh of V7. Which alto note should it resolve to in the I chord? The answer is one note name.` | `E` |
+| `parallel_fifths_octaves` | `Two voices move bass C-D and soprano G-A. Identify the error type using one of these labels: parallel fifths, parallel octaves, no parallel fifths or octaves. The answer is one label from that list.` | `parallel fifths` |
+| `invalid_harmonic_interval_structure` | `In SATB writing in C major, is a doubled leading tone valid? The answer is exactly 'yes' or 'no'.` | `no` |
+| `satb_cadence_validation` | `C: V-I has soprano B-D and bass G-C. Does the leading tone resolve correctly? The answer is exactly 'yes' or 'no'.` | `no` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `n_voices` | Number of simultaneous melodic lines to track. | all | 1-2 voices | SATB or more abstract voices |
+| `n_transitions` | Number of adjacent sonority-to-sonority moves. | all | one transition | short progressions |
+| `n_rule_families` | Number of voice-leading rule categories active in the checker. | `parallel_fifths_octaves`, `invalid_harmonic_interval_structure`, `satb_cadence_validation` | one rule | several simultaneous rule checks |
+| `n_violations` | Number of injected or reportable rule violations. | `parallel_fifths_octaves`, `invalid_harmonic_interval_structure`, `satb_cadence_validation` | 0 or 1 | all-violations output |
+| `range_span` | Allowed pitch/register span used for voicing and spacing checks. | all | narrow | wider register and spacing checks |
+
+`p_valid` is the probability that the sampler generates a valid voice-leading instance with no injected rule violation. It is a non-difficulty balancing control for the valid/invalid answer distribution, so keep it stable across levels unless there is a specific evaluation reason to bias toward valid or invalid examples.
+
+**Config sketch**
+
+```python
+@dataclass
+class VoiceLeadingConfig(Config):
+    mode: str = "any"
+    n_voices: int = 2
+    n_transitions: int = 1
+    n_rule_families: int = 1
+    n_violations: int = 1
+    range_span: int = 12
+    p_valid: float = 0.50
+
+    def update(self, c=1):
+        self.n_voices += 0.5 * c
+        self.n_transitions += 0.4 * c
+        self.n_rule_families += 0.5 * c
+        self.n_violations += 0.25 * c
+        self.range_span += 2 * c
+```
+
+**Tools:** `music21.pitch`, `music21.interval`, `music21.chord`, `music21.roman`; custom rule checker; `z3-solver` for constrained voicing generation and satisfiability checks.
+
+---
+
+## 7. `formal_music_transformations`
+
+**Stable task principle:** Given an initial formal music object and a transformation specification or examples, apply, invert, compare, or infer the transformation. The object type can be a triad, pitch-class set, motive, or harmonic pattern.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `neo_riemannian_plr` | `Apply L to a C major triad. The answer is one triad name.` | `E minor` |
+| `transformation_chain` | `Apply P then R to a C major triad. The answer is one triad name.` | `Eb major` |
+| `pitch_set_standard_form` | `Using this convention: choose the most compact normal order, then transpose the first pitch class to 0, without considering inversion. What is the standard form of pitch-class set {2, 5, 9}? The answer is one ordered tuple with no spaces, e.g. '(0,4,7)'.` | `(0,3,7)` |
+| `common_tone_comparison` | `How many common pitch classes do {0, 3, 7, 10} and {1, 4, 7, 10} share? The answer is one integer.` | `2` |
+| `finite_transposition_set` | `Transpose {0, 2, 4, 6, 8, 10} by 2 semitones. The answer is one sorted pitch-class set with no spaces, e.g. '{1,3,8}'.` | `{0,2,4,6,8,10}` |
+| `pitch_class_inversion` | `Invert ordered pitch classes (0, 4, 7) around 0. The answer is an ordered pitch-class tuple with no spaces, e.g. '(0,4,9)'.` | `(0,8,5)` |
+| `harmonic_pattern_induction` | `A rule maps each Roman numeral up one diatonic degree: I-V becomes ii-vi. Apply it to V-I. The answer is hyphen-separated Roman numerals, e.g. 'ii-V-I'.` | `vi-ii` |
+| `melodic_sequence_induction` | `Transpose motive C-D-E up a whole step. The answer is hyphen-separated note names.` | `D-E-F#` |
+| `hidden_transformation_inference` | `Examples show (0,4,7)->(2,6,9) and (6,10,1)->(8,0,3). Apply the same pitch-class transformation to (3,7,10). The answer is an ordered pitch-class tuple with no spaces, e.g. '(1,5,8)'.` | `(5,9,0)` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `object_size` | Number of elements in the pitch set, motive, or harmonic object. | `pitch_set_standard_form`, `common_tone_comparison`, `finite_transposition_set`, `pitch_class_inversion`, `melodic_sequence_induction`, `hidden_transformation_inference` | triads or trichords | larger pitch sets or motives |
+| `chain_len` | Number of transformations applied in sequence. | `neo_riemannian_plr`, `transformation_chain`, `finite_transposition_set`, `pitch_class_inversion`, `melodic_sequence_induction` | one operation | longer transformation chains |
+| `search_depth` | Maximum path length or inference depth for inverse/search tasks. | `neo_riemannian_plr`, `transformation_chain`, `hidden_transformation_inference` | direct application | shortest path or inverse search |
+| `n_examples` | Number of input-output examples shown for rule induction. | `harmonic_pattern_induction`, `melodic_sequence_induction`, `hidden_transformation_inference` | none or one | pattern induction from several examples |
+| `n_distractors` | Number of plausible but wrong options or paths. | `transformation_chain`, `common_tone_comparison`, `hidden_transformation_inference` | none | choose among plausible transformations |
+| `p_infer_rule` | Probability that the transformation rule must be inferred rather than stated. | `harmonic_pattern_induction`, `melodic_sequence_induction`, `hidden_transformation_inference` | low | more hidden-rule induction |
+
+**Config sketch**
+
+```python
+@dataclass
+class FormalTransformConfig(Config):
+    mode: str = "any"
+    object_size: int = 3
+    chain_len: int = 1
+    search_depth: int = 1
+    n_examples: int = 1
+    n_distractors: int = 0
+    p_infer_rule: float = 0.10
+
+    def update(self, c=1):
+        self.object_size += 0.4 * c
+        self.chain_len += 0.5 * c
+        self.search_depth += 0.6 * c
+        self.n_examples += 0.3 * c
+        self.n_distractors += 0.5 * c
+        self.p_infer_rule = min(0.65, self.p_infer_rule + 0.07 * c)
+```
+
+**Tools:** custom PLR and pitch-class arithmetic as source of truth; `networkx` for graph search; `numpy`/`sympy` for modular operations; `music21` for spelling and cross-checks.
+
+---
+
+## 8. `analysis_representation_reasoning`
+
+**Stable task principle:** Given a score/ABC fragment or one or more structured analysis records, convert, validate, repair, complete, or diff them under a canonical schema.
+
+**Modes**
+
+| Mode | Prompt example | Answer |
+|---|---|---|
+| `score_property_extraction` | `Given the ABC chord fragment K:C [D^FAc], extract the chord and analyze it in C major. The answer is one compact Roman numeral, e.g. 'I6' or 'V65'.` | `V7/V` |
+| `non_chord_tone_count` | `Given the ABC melody K:C C D E F G over a C major triad, count notes outside the chord tones C, E, and G. The answer is one integer.` | `2` |
+| `abc_score_parsing` | `ABC notes ^C _D E represent which written note-name sequence? The answer is comma-separated note names in order.` | `C#, Db, E` |
+| `analysis_normalization` | `Normalize "applied dominant seventh to the supertonic in C" as a Roman numeral. The answer is one Roman numeral.` | `V7/ii` |
+| `romantext_repair` | `Repair the invalid Roman label "V7V" in C major when it means dominant seventh of the dominant. The answer is one canonical Roman label.` | `V7/V` |
+| `score_to_romantext` | `Measure 3 in key G contains D-F#-A-C. The answer is one RomanText-style record in the format 'm<measure> <key>: <Roman>', e.g. 'm2 C: I6'.` | `m3 G: V7` |
+| `representation_conversion` | `Convert key=C and roman=V7 to compact text. The answer is exactly "key: roman".` | `C: V7` |
+| `semantic_diff` | `A uses V7/V; B writes D7 in key C for the same chord. Is there a semantic diff? Choose from: no semantic change, changed root, changed quality, changed inversion, changed key, changed function. The answer is one label from that list.` | `no semantic change` |
+
+**Difficulty knobs**
+
+| Knob | Description | Modes affected | Level 0 tendency | Monotonic update effect |
+|---|---|---|---|---|
+| `n_records` | Number of analysis rows, events, measures, or records. | `analysis_normalization`, `romantext_repair`, `score_to_romantext`, `representation_conversion`, `semantic_diff` | one record | multi-line analyses |
+| `n_formats` | Number of representation formats involved in the conversion/check. | `abc_score_parsing`, `score_to_romantext`, `representation_conversion`, `semantic_diff` | one source and one target | multiple intermediate formats |
+| `n_missing_fields` | Number of omitted schema fields to infer or repair. | `romantext_repair`, `score_to_romantext` | none or one | completion/repair with inherited defaults |
+| `n_edits` | Number of corruptions, repairs, or semantic diff operations. | `romantext_repair`, `semantic_diff` | one edit | structured diff lists |
+| `score_len` | Length of the score excerpt linked to the analysis record. | `score_property_extraction`, `non_chord_tone_count`, `abc_score_parsing`, `score_to_romantext` | one chord/measure | score fragments with non-chord tones |
+| `p_semantic_equiv` | Probability of textually different but semantically equivalent analyses. | `analysis_normalization`, `romantext_repair`, `representation_conversion`, `semantic_diff` | low | more textually different but equivalent labels |
+
+**Config sketch**
+
+```python
+@dataclass
+class AnalysisRepresentationConfig(Config):
+    mode: str = "any"
+    n_records: int = 1
+    n_formats: int = 1
+    n_missing_fields: int = 0
+    n_edits: int = 1
+    score_len: int = 1
+    p_semantic_equiv: float = 0.10
+
+    def update(self, c=1):
+        self.n_records += c
+        self.n_formats += 0.3 * c
+        self.n_missing_fields += 0.3 * c
+        self.n_edits += 0.4 * c
+        self.score_len += 0.5 * c
+        self.p_semantic_equiv = min(0.65, self.p_semantic_equiv + 0.06 * c)
+```
+
+**Tools:** project-owned canonical record schema; `json`, `csv`, `pandas`, `pyyaml`, `tabulate`, `pyparsing`; `music21.roman` and `music21.key` for musical validation; `whatthepatch`, `difflib`, and `rapidfuzz` for diff diagnostics.
+
+---
+
+# Dependency and Tool Inventory
+
+## Recommended New Dependency
+
+- `music21`: primary symbolic music theory engine for convention-heavy primitives. Use it for pitches, intervals, chords, keys, scales, meter/duration notation, clefs, instruments, streams, score conversion, Roman numerals, RomanText-style analysis, and verification canonicalizers.
+
+## Already Present in `pyproject.toml`
+
+- `z3-solver`: constraint solving for voice leading, unique-key inference, valid continuation search, and missing-duration solving.
+- `networkx`: graph search for Neo-Riemannian transformations, modulation/key-distance graphs, harmonic transition graphs, and shortest paths.
+- `numpy`: finite sampling, pitch-class arrays, interval vectors, balancing answer classes, and modular operations.
+- `sympy`: exact symbolic or modular arithmetic when pitch-class operations need transparent algebraic checks.
+- `nltk`, `gramforge`, `greenery`: grammar-backed generation, parsing, and regular-language subsets.
+- `pyparsing`: compact custom parsers for progressions, RomanText-like syntax, or analysis records.
+- `pandas`, `pyyaml`, `tabulate`: tabular and structured representation tasks.
+- `whatthepatch`, `rapidfuzz`: diff-style repair diagnostics and tolerant matching.
+
+---
+
+# Implementation Checklist
+
+- Keep `mode` independent of `level`; level changes instance size and complexity only.
+- Add `mode: str = "any"` to each config. When it is `"any"`, sample a concrete mode; when it is fixed, generate only that mode.
+- Store the resolved concrete mode in `metadata["mode"]`.
+- Prefer knobs such as `chain_len`, `context_len`, `n_constraints`, `n_candidates`, `n_records`, `n_edits`, `max_accidental`, and probabilities.
+- Avoid code like `if level >= 3: mode = "secondary_dominant"`.
+- Keep count-like knobs annotated as `int`; fractional updates such as `self.n_candidates += 0.5 * c` rely on Reasoning Core's stochastic rounding.
+- Use `float` annotations for probabilities or continuous controls such as `self.p_chromatic = min(...)`.
+- Keep non-difficulty balancing controls, such as valid/invalid mixture probabilities, separate from level-driven difficulty knobs.
+- Rely on framework fields such as `_task`, `_level`, and `_config` instead of duplicating them in task-owned metadata.
+- Store the hidden formal state in metadata.
+- Generate `cot` from the solver's logged intermediate steps and the same symbolic operations used to compute the answer, not from a separate natural-language explanation.
+- Make answer formats explicit in prompts and canonical in `score_answer`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "xpflow",
     "exrex",
     "nltk",
+    "music21",
     "wordfreq",
     "pgmpy",
     "unification",

--- a/reasoning_core/tasks/_music_theory.py
+++ b/reasoning_core/tasks/_music_theory.py
@@ -1,0 +1,1252 @@
+from dataclasses import dataclass
+from collections.abc import Sequence
+import random
+import re
+from typing import Any
+
+from music21 import chord as m21_chord
+
+LETTERS = "CDEFGAB"
+STEP = {letter: i for i, letter in enumerate(LETTERS)}
+NATURAL_PC = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
+PITCH_CLASS_LABELS = ("C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B")
+ACC_TO_INT = {"bb": -2, "b": -1, "": 0, "#": 1, "##": 2}
+INT_TO_ACC = {v: k for k, v in ACC_TO_INT.items()}
+ACCIDENTAL_WEIGHTS = {
+    0: 6,
+    -1: 3,
+    1: 3,
+    -2: 1,
+    2: 1,
+}
+GENERATION_RETRY_LIMIT = 128
+SPN_STYLE = "spn"
+COMPACT_ABC_STYLE = "compact_abc"
+FULL_ABC_SCORE_STYLE = "full_abc_score"
+FULL_ABC_SCORE_SHARE = 0.3
+ABC_DEFAULT_LENGTHS = ("1/4", "1/8", "1/16")
+ABC_EVENT_DURATIONS = (1, 2, 4)
+ABC_OMIT_DURATION_SHARE = 0.3
+ABC_METERS = ("none", "2/4", "3/4", "4/4", "6/8", "9/8", "12/8")
+ABC_KEYS = ("C", "G", "D", "A", "E", "F", "Bb", "Eb", "Ab", "Am", "Em", "Bm", "F#m", "Dm", "Gm", "Cm", "Fm")
+ABC_EXPLICIT_ACCIDENTAL_SHARE = 0.1
+ABC_KEY_SIGNATURES = {
+    "C": {},
+    "G": {"F": 1},
+    "D": {"F": 1, "C": 1},
+    "A": {"F": 1, "C": 1, "G": 1},
+    "E": {"F": 1, "C": 1, "G": 1, "D": 1},
+    "F": {"B": -1},
+    "Bb": {"B": -1, "E": -1},
+    "Eb": {"B": -1, "E": -1, "A": -1},
+    "Ab": {"B": -1, "E": -1, "A": -1, "D": -1},
+    "Am": {},
+    "Em": {"F": 1},
+    "Bm": {"F": 1, "C": 1},
+    "F#m": {"F": 1, "C": 1, "G": 1},
+    "Dm": {"B": -1},
+    "Gm": {"B": -1, "E": -1},
+    "Cm": {"B": -1, "E": -1, "A": -1},
+    "Fm": {"B": -1, "E": -1, "A": -1, "D": -1},
+}
+ABC_ACCIDENTAL_PREFIX = {2: "^^", 1: "^", 0: "=", -1: "_", -2: "__"}
+ACCIDENTAL_WORDS = {
+    2: "double sharp",
+    1: "sharp",
+    0: "natural",
+    -1: "flat",
+    -2: "double flat",
+}
+NUMBER_NAMES = {
+    1: "unison",
+    2: "second",
+    3: "third",
+    4: "fourth",
+    5: "fifth",
+    6: "sixth",
+    7: "seventh",
+    8: "octave",
+    9: "ninth",
+    10: "tenth",
+    11: "eleventh",
+    12: "twelfth",
+    13: "thirteenth",
+    14: "fourteenth",
+    15: "fifteenth",
+    16: "sixteenth",
+    17: "seventeenth",
+    18: "eighteenth",
+    19: "nineteenth",
+    20: "twentieth",
+}
+BASE_INTERVAL_SEMITONES = {1: 0, 2: 2, 3: 4, 4: 5, 5: 7, 6: 9, 7: 11}
+PERFECT_SIMPLE_NUMBERS = {1, 4, 5}
+PERFECT_INTERVAL_NAMES = {
+    name for number, name in NUMBER_NAMES.items()
+    if ((number - 1) % 7) + 1 in PERFECT_SIMPLE_NUMBERS
+}
+QUALITY_OFFSETS = {
+    "perfect": 0,
+    "major": 0,
+    "minor": -1,
+    "augmented": 1,
+    "double-augmented": 2,
+}
+PERFECT_QUALITY_OFFSETS = {
+    **QUALITY_OFFSETS,
+    "diminished": -1,
+    "double-diminished": -2,
+}
+IMPERFECT_QUALITY_OFFSETS = {
+    **QUALITY_OFFSETS,
+    "diminished": -2,
+    "double-diminished": -3,
+}
+PERFECT_QUALITY_BY_OFFSET = {
+    0: "perfect",
+    1: "augmented",
+    2: "double-augmented",
+    -1: "diminished",
+    -2: "double-diminished",
+}
+IMPERFECT_QUALITY_BY_OFFSET = {
+    0: "major",
+    -1: "minor",
+    1: "augmented",
+    2: "double-augmented",
+    -2: "diminished",
+    -3: "double-diminished",
+}
+# Interval inversion swaps the two notes of an interval. The interval number
+# changes so simple numbers add to 9, and the quality changes by convention:
+# major <-> minor, augmented <-> diminished, perfect stays perfect.
+QUALITY_INVERSION = {
+    "perfect": "perfect",
+    "major": "minor",
+    "minor": "major",
+    "augmented": "diminished",
+    "diminished": "augmented",
+    "double-augmented": "double-diminished",
+    "double-diminished": "double-augmented",
+}
+QUALITY_WEIGHTS = {
+    "perfect": 5,
+    "major": 5,
+    "minor": 5,
+    "augmented": 2,
+    "diminished": 2,
+    "double-augmented": 1,
+    "double-diminished": 1,
+}
+
+# Conventional key-signature spellings used for key-context tasks. These are
+# the standard 15 major and 15 minor key names, avoiding theoretical key
+# signatures outside the usual circle-of-fifths spellings.
+MAJOR_KEY_TONICS = ("Cb", "Gb", "Db", "Ab", "Eb", "Bb", "F", "C", "G", "D", "A", "E", "B", "F#", "C#")
+MINOR_KEY_TONICS = ("Ab", "Eb", "Bb", "F", "C", "G", "D", "A", "E", "B", "F#", "C#", "G#", "D#", "A#")
+MAJOR_KEY_COMPLEXITY = {
+    "C": 0,
+    "G": 1,
+    "D": 2,
+    "A": 3,
+    "E": 4,
+    "B": 5,
+    "F#": 6,
+    "C#": 7,
+    "F": 1,
+    "Bb": 2,
+    "Eb": 3,
+    "Ab": 4,
+    "Db": 5,
+    "Gb": 6,
+    "Cb": 7,
+}
+MINOR_KEY_COMPLEXITY = {
+    "A": 0,
+    "E": 1,
+    "B": 2,
+    "F#": 3,
+    "C#": 4,
+    "G#": 5,
+    "D#": 6,
+    "A#": 7,
+    "D": 1,
+    "G": 2,
+    "C": 3,
+    "F": 4,
+    "Bb": 5,
+    "Eb": 6,
+    "Ab": 7,
+}
+MINOR_SCALE_MODES = (
+    ("natural_minor", "natural minor"),
+    ("harmonic_minor", "harmonic minor"),
+    ("melodic_minor_ascending", "melodic minor ascending"),
+)
+
+
+def key_tonics(mode: str, key_complexity: int = 7) -> tuple[str, ...]:
+    """Return conventional key tonics within a key-signature complexity bound."""
+    key_complexity = max(0, min(7, int(key_complexity)))
+    if mode == "major":
+        return tuple(
+            tonic for tonic in MAJOR_KEY_TONICS
+            if MAJOR_KEY_COMPLEXITY[tonic] <= key_complexity
+        )
+    if mode == "minor":
+        return tuple(
+            tonic for tonic in MINOR_KEY_TONICS
+            if MINOR_KEY_COMPLEXITY[tonic] <= key_complexity
+        )
+    raise ValueError(f"Unsupported key mode: {mode}")
+
+
+# Consonances are relatively stable diatonic intervals, dissonances are
+# unstable but still in-key intervals, and chromatic alterations use notes
+# outside the key collection.
+INTERVAL_CLASS_LABELS = (
+    "diatonic consonance",
+    "diatonic dissonance",
+    "chromatic alteration",
+)
+CONSONANT_INTERVAL_SIMPLE_NUMBERS = {1, 3, 5, 6}
+CONSONANT_INTERVAL_QUALITIES = {"perfect", "major", "minor"}
+
+CHOICE_TAILS = (
+    "Choose from: {options}. The answer is one label from that list.",
+    "Use one of these labels: {options}. The answer is one label from that list.",
+    "Select exactly one label from this list: {options}.",
+    "The answer is exactly one of these labels: {options}.",
+    "Answer with exactly one label from: {options}.",
+)
+YES_NO_TAILS = (
+    "The answer is exactly 'yes' or 'no'.",
+    "Answer exactly 'yes' or 'no'.",
+    "The expected answer is one word: 'yes' or 'no'.",
+    "Give one answer, either 'yes' or 'no'.",
+    "Respond with exactly one word: 'yes' or 'no'.",
+)
+INTEGER_TAILS = (
+    "The answer is one integer.",
+    "Give one integer.",
+    "Answer with one integer.",
+    "Respond with a single integer.",
+)
+NOTE_ANSWER_TAILS = (
+    "The answer is {answer_format}.",
+    "Give {answer_format}.",
+    "Answer with {answer_format}.",
+    "Provide {answer_format}.",
+)
+
+@dataclass(frozen=True)
+class Note:
+    """A written pitch spelling, e.g. Note("F", 1, 4) represents F#4."""
+
+    letter: str
+    accidental: int = 0
+    octave: int | None = None
+
+    @property
+    def pc(self) -> int:
+        """Return the pitch class, where C is 0 and B is 11."""
+        return (NATURAL_PC[self.letter] + self.accidental) % 12
+
+    @property
+    def step(self) -> int:
+        """Return the diatonic letter index, where C is 0 and B is 6."""
+        return STEP[self.letter]
+
+    @property
+    def diatonic_number(self) -> int:
+        """Return an octave-aware diatonic position for interval-number math."""
+        if self.octave is None:
+            raise ValueError("Cannot compute diatonic number without octave.")
+        return self.octave * 7 + self.step
+
+    @property
+    def semitone_number(self) -> int:
+        """Return an octave-aware chromatic position for semitone-distance math."""
+        if self.octave is None:
+            raise ValueError("Cannot compute semitone number without octave.")
+        return self.octave * 12 + NATURAL_PC[self.letter] + self.accidental
+
+    def name(self, with_octave: bool | None = None) -> str:
+        """Render the note as a compact name such as 'F#4' or 'Bb' (scientific pitch notation)."""
+        if with_octave is None:
+            with_octave = self.octave is not None
+        suffix = "" if not with_octave or self.octave is None else str(self.octave)
+        return f"{self.letter}{INT_TO_ACC[self.accidental]}{suffix}"
+
+    def without_octave(self) -> "Note":
+        """Return the same written note without octave information."""
+        return Note(self.letter, self.accidental)
+
+    def same_spelling(self, other: "Note", include_octave: bool = False) -> bool:
+        """Return whether another note has the same written spelling."""
+        same_pitch_name = self.letter == other.letter and self.accidental == other.accidental
+        if include_octave:
+            return same_pitch_name and self.octave == other.octave
+        return same_pitch_name
+
+    def same_pitch(self, other: "Note") -> bool:
+        """Return whether another note sounds as the same pitch."""
+        if self.octave is None or other.octave is None:
+            return self.pc == other.pc
+        return self.semitone_number == other.semitone_number
+
+    @classmethod
+    def parse(cls, text: object, default_octave: int | None = None) -> "Note":
+        """Parse a note in scientific pitch notation into a Note object."""
+        text = "".join(AnswerNormalizer.normalize_text(text).split())
+        m = re.fullmatch(r"([A-Ga-g])((?:bb)|(?:##)|b|#)?(-?\d+)?", text)
+        if not m:
+            raise ValueError(f"Invalid note name: {text!r}")
+        letter, accidental, octave = m.groups()
+        octave = default_octave if octave is None else int(octave)
+        return cls(letter.upper(), ACC_TO_INT[accidental or ""], octave)
+
+    @staticmethod
+    def random_accidental(limit: int, weights_by_accidental: dict[int, float] = ACCIDENTAL_WEIGHTS) -> int:
+        """Sample an accidental, favoring simpler spellings."""
+        choices = [0]
+        if limit >= 1:
+            choices += [-1, 1]
+        if limit >= 2:
+            choices += [-2, 2]
+        weights = [weights_by_accidental[a] for a in choices]
+        return random.choices(choices, weights=weights, k=1)[0]
+
+    @classmethod
+    def random(
+        cls,
+        config: "PitchIntervalConfig",
+        with_octave: bool = True,
+        octave_min: int = 3,
+        octave_max: int = 5,
+        accidental_limit: int | None = None,
+    ) -> "Note":
+        """Sample a random written note within a modest octave range."""
+        accidental_limit = config.max_accidental if accidental_limit is None else accidental_limit
+        octave = random.randint(octave_min, octave_max) if with_octave else None
+        return cls(random.choice(LETTERS), cls.random_accidental(accidental_limit), octave)
+
+    def exact_pitch_spellings(self, accidental_limit: int) -> list["Note"]:
+        """Return written spellings that sound as the same octave-bearing pitch."""
+        if self.octave is None:
+            raise ValueError("Exact-pitch spellings require an octave.")
+
+        spellings = []
+        target = self.semitone_number
+        for letter in LETTERS:
+            for accidental in range(-accidental_limit, accidental_limit + 1):
+                octave_offset = target - NATURAL_PC[letter] - accidental
+                if octave_offset % 12 == 0:
+                    spellings.append(Note(letter, accidental, octave_offset // 12))
+        return spellings
+
+    @classmethod
+    def spellings_for_pitch_class(
+        cls,
+        pc: int,
+        accidental_limit: int,
+        with_octave: bool = True,
+        octave_min: int = 2,
+        octave_max: int = 6,
+    ) -> list["Note"]:
+        """List note spellings for a pitch class within an accidental limit."""
+        notes = []
+        for letter in LETTERS:
+            for accidental in range(-accidental_limit, accidental_limit + 1):
+                if (NATURAL_PC[letter] + accidental) % 12 == pc:
+                    octave = random.randint(octave_min, octave_max) if with_octave else None
+                    notes.append(cls(letter, accidental, octave))
+        return notes
+
+
+@dataclass(frozen=True)
+class Interval:
+    """A named interval, optionally anchored to concrete start/end notes.
+
+    The quality and number are the stable interval identity. Endpoints are
+    stored only when a mode needs note-pair context; endpoint-dependent methods
+    check that the needed octave information is actually present.
+    """
+
+    quality: str
+    number: int
+    start: Note | None = None
+    end: Note | None = None
+
+    @classmethod
+    def between(cls, start: Note, end: Note, without_octaves: bool = False) -> "Interval":
+        """Compute the named interval between two notes.
+
+        With ``without_octaves=True``, use the task's simple ascending interval
+        convention for octave-free note names and do not store concrete
+        endpoints, because no precise compound interval is implied.
+        """
+        if without_octaves:
+            calc_start = Note(start.letter, start.accidental, 4)
+            octave = 4 if end.step >= start.step else 5
+            calc_end = Note(end.letter, end.accidental, octave)
+            start_for_storage = None
+            end_for_storage = None
+        else:
+            calc_start = start
+            calc_end = end
+            start_for_storage = start
+            end_for_storage = end
+        number = abs(calc_end.diatonic_number - calc_start.diatonic_number) + 1
+        semitones = abs(calc_end.semitone_number - calc_start.semitone_number)
+        quality = cls.quality_from_distance(number, semitones)
+        return cls(quality, number, start_for_storage, end_for_storage)
+
+    @staticmethod
+    def simple_number_for(number: int) -> int:
+        """Reduce any interval number to its simple interval number."""
+        return ((number - 1) % 7) + 1
+
+    @staticmethod
+    def base_semitones_for(number: int) -> int:
+        """Return semitones for the major/perfect form of an interval number."""
+        simple = Interval.simple_number_for(number)
+        octaves = (number - 1) // 7
+        return BASE_INTERVAL_SEMITONES[simple] + 12 * octaves
+
+    @staticmethod
+    def semitones_for(quality: str, number: int) -> int:
+        """Return semitone size for an interval quality and number."""
+        simple = Interval.simple_number_for(number)
+        base = Interval.base_semitones_for(number)
+        offsets = PERFECT_QUALITY_OFFSETS if simple in PERFECT_SIMPLE_NUMBERS else IMPERFECT_QUALITY_OFFSETS
+        offset = offsets[quality]
+        return base + offset
+
+    @staticmethod
+    def quality_from_distance(number: int, semitones: int) -> str:
+        """Infer interval quality from interval number and semitone distance."""
+        simple = Interval.simple_number_for(number)
+        diff = semitones - Interval.base_semitones_for(number)
+        table = PERFECT_QUALITY_BY_OFFSET if simple in PERFECT_SIMPLE_NUMBERS else IMPERFECT_QUALITY_BY_OFFSET
+        if diff not in table:
+            raise ValueError("Unsupported interval quality.")
+        return table[diff]
+
+    @staticmethod
+    def quality_options(number: int, accidental_limit: int) -> list[str]:
+        """Return interval qualities allowed for a number and accidental limit."""
+        simple = Interval.simple_number_for(number)
+        if simple in PERFECT_SIMPLE_NUMBERS:
+            qualities = ["perfect"]
+        else:
+            qualities = ["major", "minor"]
+        if accidental_limit >= 1:
+            qualities += ["augmented", "diminished"]
+        if accidental_limit >= 2:
+            qualities += ["double-augmented", "double-diminished"]
+        return [quality for quality in qualities if Interval.semitones_for(quality, number) >= 0]
+
+    @classmethod
+    def random(
+        cls,
+        config: "PitchIntervalConfig",
+        min_number: int = 1,
+        max_number: int | None = None,
+        compound: bool = False,
+        accidental_limit: int | None = None,
+        weights_by_quality: dict[str, float] = QUALITY_WEIGHTS,
+    ) -> "Interval":
+        """Sample an interval quality and number from the current difficulty range."""
+        max_number = max_number or config.max_interval_number
+        accidental_limit = config.max_accidental if accidental_limit is None else accidental_limit
+        if compound:
+            low = max(9, min_number)
+            high = max(low, max_number)
+        else:
+            low = min_number
+            high = max(low, max_number)
+        number = random.randint(low, high)
+        qualities = cls.quality_options(number, accidental_limit)
+        weights = [weights_by_quality[q] for q in qualities]
+        return cls(random.choices(qualities, weights=weights, k=1)[0], number)
+
+    def name(self) -> str:
+        """Return the readable interval name, such as 'major third'."""
+        return f"{self.quality} {self.number_name}"
+
+    @property
+    def number_name(self) -> str:
+        """Return the interval-number name, such as 'third'."""
+        return NUMBER_NAMES[self.number]
+
+    @property
+    def simple_number(self) -> int:
+        """Return the simple interval number after octave reduction."""
+        return self.simple_number_for(self.number)
+
+    @property
+    def base_semitones(self) -> int:
+        """Return semitones in the major/perfect reference form."""
+        return self.base_semitones_for(self.number)
+
+    @property
+    def semitones(self) -> int:
+        """Return semitones in this named interval."""
+        return self.semitones_for(self.quality, self.number)
+
+    @property
+    def step_count(self) -> int:
+        """Return letter steps moved from start to target."""
+        return self.number - 1
+
+    @property
+    def chromatic_distance(self) -> int:
+        """Return endpoint semitone distance for a concrete note-pair interval."""
+        if self.start is None or self.end is None:
+            raise ValueError("Chromatic distance requires concrete interval endpoints.")
+        return abs(self.end.semitone_number - self.start.semitone_number)
+
+    def reduced(self) -> "Interval":
+        """Return the simple interval obtained by removing compound octaves."""
+        return Interval(self.quality, self.simple_number)
+
+    def inverted(self) -> "Interval":
+        """Return this interval's inversion."""
+        inverted_number = 9 - self.simple_number
+        return Interval(QUALITY_INVERSION[self.quality], inverted_number)
+
+    def add(self, other: "Interval") -> "Interval":
+        """Return the interval produced by stacking another interval above this one."""
+        number = self.number + other.number - 1
+        semitones = self.semitones + other.semitones
+        quality = self.quality_from_distance(number, semitones)
+        return Interval(quality, number)
+
+    def subtract(self, other: "Interval") -> "Interval":
+        """Return the interval left after removing another interval from this one."""
+        number = self.number - other.number + 1
+        semitones = self.semitones - other.semitones
+        if number < 1 or semitones < 0:
+            raise ValueError("Interval subtraction produced an invalid interval.")
+        quality = self.quality_from_distance(number, semitones)
+        return Interval(quality, number)
+
+    def construct_from(self, start: Note, direction: str = "up") -> Note:
+        """Construct the note at this interval above or below a start note."""
+        return_without_octave = start.octave is None
+        if return_without_octave:
+            start = Note(start.letter, start.accidental, 4)
+
+        sign = 1 if direction == "up" else -1
+        target_diatonic = start.diatonic_number + sign * self.step_count
+        target_octave, target_step = divmod(target_diatonic, 7)
+        target_letter = LETTERS[target_step]
+        target_semitone = start.semitone_number + sign * self.semitones
+        natural_target = target_octave * 12 + NATURAL_PC[target_letter]
+        accidental = target_semitone - natural_target
+        if accidental not in INT_TO_ACC:
+            raise ValueError("Constructed pitch needs an unsupported accidental.")
+        if return_without_octave:
+            return Note(target_letter, accidental)
+        return Note(target_letter, accidental, target_octave)
+
+    def is_consonant(self) -> bool:
+        """Return whether this interval is consonant under this task's convention."""
+        return (
+            self.quality in CONSONANT_INTERVAL_QUALITIES
+            and self.simple_number in CONSONANT_INTERVAL_SIMPLE_NUMBERS
+        )
+
+    def same_endpoint_pitches(self, other: "Interval") -> bool:
+        """Return whether two concrete intervals have the same sounding endpoints."""
+        if self.start is None or self.end is None or other.start is None or other.end is None:
+            raise ValueError("Endpoint-pitch comparison requires concrete intervals.")
+        return self.start.same_pitch(other.start) and self.end.same_pitch(other.end)
+
+
+@dataclass(frozen=True)
+class Scale:
+    """A diatonic collection used for key-context classification tasks."""
+
+    tonic: Note
+    mode: str
+    degrees: tuple[Note, ...]
+
+    @classmethod
+    def build(cls, tonic: Note, mode: str) -> "Scale":
+        """Build a major, natural-minor, harmonic-minor, or melodic-minor scale."""
+        if mode == "major":
+            degree_intervals = (
+                ("perfect", 1),
+                ("major", 2),
+                ("major", 3),
+                ("perfect", 4),
+                ("perfect", 5),
+                ("major", 6),
+                ("major", 7),
+            )
+        elif mode in {"minor", "natural_minor"}:
+            degree_intervals = (
+                ("perfect", 1),
+                ("major", 2),
+                ("minor", 3),
+                ("perfect", 4),
+                ("perfect", 5),
+                ("minor", 6),
+                ("minor", 7),
+            )
+        elif mode == "harmonic_minor":
+            degree_intervals = (
+                ("perfect", 1),
+                ("major", 2),
+                ("minor", 3),
+                ("perfect", 4),
+                ("perfect", 5),
+                ("minor", 6),
+                ("major", 7),
+            )
+        elif mode == "melodic_minor_ascending":
+            degree_intervals = (
+                ("perfect", 1),
+                ("major", 2),
+                ("minor", 3),
+                ("perfect", 4),
+                ("perfect", 5),
+                ("major", 6),
+                ("major", 7),
+            )
+        else:
+            raise ValueError(f"Unsupported key mode: {mode}")
+
+        degrees = tuple(
+            Interval(quality, number).construct_from(tonic).without_octave()
+            for quality, number in degree_intervals
+        )
+        return cls(tonic, mode, degrees)
+
+    def contains(self, note: Note) -> bool:
+        """Return whether a written note spelling belongs to this scale."""
+        return any(note.same_spelling(degree) for degree in self.degrees)
+
+    def chromatic_alterations(self) -> list[Note]:
+        """Return one-accidental alterations of scale degrees that leave the scale."""
+        alterations = []
+        for degree in self.degrees:
+            for direction in [-1, 1]:
+                altered_acc = degree.accidental + direction
+                if altered_acc in INT_TO_ACC:
+                    altered = Note(degree.letter, altered_acc)
+                    if not self.contains(altered):
+                        alterations.append(altered)
+        return alterations
+
+    def relation_label(self, first: Note, second: Note) -> str:
+        """Classify a note-to-note relation as diatonic consonance/dissonance/chromatic."""
+        if not self.contains(first) or not self.contains(second):
+            return "chromatic alteration"
+
+        interval = Interval.between(first, second, without_octaves=True)
+        if interval.is_consonant():
+            return "diatonic consonance"
+        return "diatonic dissonance"
+
+    def alter_note_outside(self, note: Note, accidental_limit: int) -> Note:
+        """Alter one note until it no longer belongs to this scale."""
+        for delta in random.sample((1, -1, 2, -2), 4):
+            altered = Note(note.letter, note.accidental + delta)
+            if abs(altered.accidental) <= accidental_limit and not self.contains(altered):
+                return altered
+        raise ValueError("Could not alter note outside the scale.")
+
+
+class AnswerNormalizer:
+    """Normalization rules used by answer parsing and scoring."""
+
+    @staticmethod
+    def normalize_text(text: object) -> str:
+        """Normalize common answer spelling variants before scoring."""
+        text = (
+            str(text)
+            .strip()
+            .rstrip(".")
+            .replace("♯", "#")
+            .replace("♭", "b")
+            .replace("𝄪", "##")
+            .replace("𝄫", "bb")
+        )
+
+        def replace_accidental_word(match: re.Match[str]) -> str:
+            """Convert one regex match like 'E-flat' into compact spelling 'Eb'."""
+            letter, accidental, octave = match.groups()
+            accidental = accidental.lower().replace("-", " ")
+            acc = {
+                "flat": "b",
+                "sharp": "#",
+                "natural": "",
+                "double flat": "bb",
+                "double sharp": "##",
+            }[" ".join(accidental.split())]
+            return f"{letter}{acc}{octave or ''}"
+
+        # Accept common note-answer spellings such as "E-flat", "E flat",
+        # "F double-sharp", and "C natural" in addition to compact "Eb"/"F##"/"C".
+        return re.sub(
+            r"\b([A-Ga-g])\s*(?:-| )\s*(double\s*[- ]\s*flat|double\s*[- ]\s*sharp|flat|sharp|natural)\s*(-?\d+)?\b",
+            replace_accidental_word,
+            text,
+        )
+
+    @staticmethod
+    def text(text: object) -> str:
+        """Normalize general text answers for exact symbolic comparison."""
+        return " ".join(AnswerNormalizer.normalize_text(text).lower().split())
+
+    @staticmethod
+    def interval(text: object) -> str:
+        """Normalize interval-answer aliases that preserve exact interval identity."""
+        text = " ".join(AnswerNormalizer.text(text).replace("-", " ").split())
+        if text in {"double octave", "perfect double octave"}:
+            return "perfect fifteenth"
+        if text in PERFECT_INTERVAL_NAMES:
+            return f"perfect {text}"
+        return text
+
+    @staticmethod
+    def note(text: object, answer_notation: str | None = None) -> str:
+        """Normalize note answers while preserving strict written spelling."""
+        text = AnswerNormalizer.normalize_text(text).replace(" ", "")
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"', "`"}:
+            text = text[1:-1]
+        if type(answer_notation) == str and "ABC" in answer_notation:
+            return re.sub(r"^=([A-Ga-g][,']*)$", r"\1", text)
+
+        m = re.fullmatch(r"([A-Ga-g])((?:bb)|(?:##)|b|#)?(-?\d+)?", text)
+        if not m:
+            return text.lower()
+        letter, acc, octave = m.groups()
+        return f"{letter.upper()}{acc or ''}{octave or ''}"
+
+    @staticmethod
+    def roman(text: object) -> str:
+        """Normalize compact Roman-numeral answers without changing case semantics."""
+        return "".join(AnswerNormalizer.normalize_text(text).split()).replace("ø", "/o")
+
+    @staticmethod
+    def note_sequence(text: object, answer_notation: str | None = None) -> tuple[str, ...]:
+        """Normalize a hyphen-separated sequence of note names."""
+        raw_notes = AnswerNormalizer.normalize_text(text).split("-")
+        return tuple(AnswerNormalizer.note(note.strip(), answer_notation) for note in raw_notes if note.strip())
+
+
+@dataclass(frozen=True)
+class ABCContext:
+    """ABC header fields plus the key-signature accidentals implied by K:."""
+
+    default_length: str
+    meter: str
+    key: str
+    key_signature: dict[str, int]
+
+    def header(self) -> str:
+        """Render the ABC header text for this context."""
+        return f"L:{self.default_length}\nM:{self.meter}\nK:{self.key}"
+
+    @classmethod
+    def random(cls) -> "ABCContext":
+        """Sample a common ABC header context and its key signature."""
+        key = random.choice(ABC_KEYS)
+        return cls(
+            default_length=random.choice(ABC_DEFAULT_LENGTHS),
+            meter=random.choice(ABC_METERS),
+            key=key,
+            key_signature=ABC_KEY_SIGNATURES[key],
+        )
+
+    @staticmethod
+    def pitch_body(note: Note) -> str:
+        """Render the ABC letter and octave markers, without accidental prefix."""
+        if note.octave is None:
+            return note.letter
+
+        absolute_diatonic_index = (note.octave - 4) * 7 + note.step
+        if absolute_diatonic_index < 0:
+            commas = (-absolute_diatonic_index + 6) // 7
+            return f"{note.letter}{',' * commas}"
+        if absolute_diatonic_index < 7:
+            return note.letter
+        apostrophes = (absolute_diatonic_index - 7) // 7
+        octave_marks = "'" * apostrophes
+        return f"{note.letter.lower()}{octave_marks}"
+
+    @staticmethod
+    def note_token(note: Note, written_accidental: int | None) -> str:
+        """Render an ABC note token, optionally omitting the accidental prefix."""
+        prefix = "" if written_accidental is None else ABC_ACCIDENTAL_PREFIX[written_accidental]
+        return f"{prefix}{ABCContext.pitch_body(note)}"
+
+    @staticmethod
+    def duration_suffix(duration: int | None = None) -> str:
+        """Render an optional ABC duration suffix after a note or chord."""
+        if duration is None and random.random() < ABC_OMIT_DURATION_SHARE:
+            return ""
+        duration = random.choice(ABC_EVENT_DURATIONS) if duration is None else duration
+        return str(duration)
+
+    @staticmethod
+    def compact_note(note: Note, force_natural: bool = False) -> str:
+        """Render a compact ABC note token outside a full-score context."""
+        written_accidental = note.accidental if note.accidental != 0 or force_natural else None
+        return ABCContext.note_token(note, written_accidental)
+
+    @staticmethod
+    def quote_note_token(token: str) -> str:
+        """Quote a standalone ABC note token so octave commas read as notation."""
+        return f'"{token}"'
+
+    def render_event(
+        self,
+        note: Note,
+        with_octave: bool | None = None,
+        duration: int | None = None,
+        explicit_accidental: bool | None = None,
+    ) -> "ABCRenderedNote":
+        """Render one ABC event while resolving omitted accidentals through K:."""
+        if with_octave is not None:
+            note = Note(note.letter, note.accidental, note.octave if with_octave else None)
+
+        key_accidental = self.key_signature.get(note.letter, 0)
+        if explicit_accidental is None:
+            explicit_accidental = note.accidental != key_accidental or random.random() < ABC_EXPLICIT_ACCIDENTAL_SHARE
+        written_accidental = note.accidental if explicit_accidental else None
+        token = self.note_token(note, written_accidental)
+        duration_suffix = self.duration_suffix(duration)
+        return ABCRenderedNote(
+            note=note,
+            token=token,
+            event=f"{token}{duration_suffix}",
+            explicit_accidental=explicit_accidental,
+            key_accidental=key_accidental,
+        )
+
+    def score_text(self, events: Sequence[str]) -> str:
+        """Render a full ABC score from already rendered events."""
+        return f"{self.header()}\n  {' | '.join(events)} |] %1"
+
+    def resolution_sentence(self, rendered: "ABCRenderedNote") -> str:
+        """Explain how one ABC score token resolves after applying the key."""
+        score_note = self.quote_note_token(rendered.token)
+        resolved_note = NoteRenderer.note(rendered.note, COMPACT_ABC_STYLE, force_natural=True)
+        word = ACCIDENTAL_WORDS[rendered.note.accidental]
+        if rendered.explicit_accidental:
+            override = f", overriding K:{self.key}" if rendered.key_accidental != 0 and rendered.key_accidental != rendered.note.accidental else ""
+            return f"The score note {score_note} explicitly marks {rendered.note.letter} {word}{override}, so it represents {resolved_note}."
+
+        key_word = ACCIDENTAL_WORDS[rendered.key_accidental]
+        if rendered.key_accidental == 0:
+            return f"In K:{self.key}, {rendered.note.letter} has no key-signature accidental, so the score note {score_note} represents {resolved_note}."
+        return f"The key signature K:{self.key} makes {rendered.note.letter} {key_word}, so the score note {score_note} represents {resolved_note}."
+
+    def score(self, notes: Sequence[Note], with_octave: bool | None = None, force_natural: bool = False) -> str:
+        """Render one or more notes as a small full ABC score fragment."""
+        rendered = [
+            self.render_event(note, with_octave=with_octave, explicit_accidental=True if force_natural else None)
+            for note in notes
+        ]
+        return self.score_text([note.event for note in rendered])
+
+    @classmethod
+    def random_score(cls, notes: Sequence[Note], with_octave: bool | None = None, force_natural: bool = False) -> str:
+        """Render a small full ABC score fragment in a sampled context."""
+        return cls.random().score(notes, with_octave, force_natural)
+
+    @classmethod
+    def interval_score(cls, start: Note, end: Note, with_octave: bool = True, interval_number: int | None = None) -> str:
+        """Render two notes as one harmonic ABC interval."""
+        score, _, _ = cls.interval_score_with_resolution(start, end, with_octave, interval_number)
+        return score
+
+    @classmethod
+    def interval_score_with_resolution(
+        cls,
+        start: Note,
+        end: Note,
+        with_octave: bool = True,
+        interval_number: int | None = None,
+    ) -> tuple[str, tuple["ABCRenderedNote", "ABCRenderedNote"], "ABCContext"]:
+        """Render a harmonic ABC interval and keep key-resolution data."""
+        if not with_octave:
+            if interval_number is None:
+                raise ValueError("Rendering an octave-less full ABC interval requires an interval number.")
+            start = Note(start.letter, start.accidental, 4)
+            target_diatonic = start.diatonic_number + interval_number - 1
+            end_octave, end_step = divmod(target_diatonic, 7)
+            if end_step != end.step:
+                raise ValueError("Interval number does not match the endpoint letters.")
+            end = Note(end.letter, end.accidental, end_octave)
+        duration_suffix = cls.duration_suffix()
+        context = cls.random()
+        rendered_start = context.render_event(start)
+        rendered_end = context.render_event(end)
+        interval_event = f"[{rendered_start.token}{rendered_end.token}]{duration_suffix}"
+        return context.score_text([interval_event]), (rendered_start, rendered_end), context
+
+@dataclass(frozen=True)
+class ABCRenderedNote:
+    """A score token and the resolved pitch it represents in its ABC key."""
+
+    note: Note
+    token: str
+    event: str
+    explicit_accidental: bool
+    key_accidental: int
+
+class NoteRenderer:
+    """Rendering rules for prompt notes, answers, and note sequences."""
+
+    @staticmethod
+    def note(
+        note: Note,
+        style: str = SPN_STYLE,
+        with_octave: bool | None = None,
+        force_natural: bool = False,
+        quote_abc: bool = True,
+    ) -> str:
+        """Render a note; quote standalone compact ABC tokens for display by default."""
+        if style == SPN_STYLE:
+            return note.name(with_octave)
+
+        if style == COMPACT_ABC_STYLE:
+            if with_octave is None:
+                token = ABCContext.compact_note(note, force_natural)
+                return ABCContext.quote_note_token(token) if quote_abc else token
+
+            abc_note = Note(note.letter, note.accidental, note.octave if with_octave else None)
+            token = ABCContext.compact_note(abc_note, force_natural)
+            return ABCContext.quote_note_token(token) if quote_abc else token
+
+        if style == FULL_ABC_SCORE_STYLE:
+            return ABCContext.random_score([note], with_octave, force_natural)
+
+        raise ValueError(f"Unsupported note rendering style: {style}")
+
+    @staticmethod
+    def sequence(notes: Sequence[Note], style: str, with_octave: bool | None = True) -> tuple[str, list[str], list[str]]:
+        """Render a note sequence, resolved display tokens, and resolution CoT."""
+        if style == FULL_ABC_SCORE_STYLE:
+            context = ABCContext.random()
+            rendered = [context.render_event(note, with_octave=with_octave) for note in notes]
+            rendered_text = context.score_text([note.event for note in rendered])
+            resolved_notes = [
+                NoteRenderer.note(note.note, COMPACT_ABC_STYLE, force_natural=True)
+                for note in rendered
+            ]
+            resolution_cot = [context.resolution_sentence(note) for note in rendered]
+            return rendered_text, resolved_notes, resolution_cot
+
+        rendered_notes = [NoteRenderer.note(note, style, with_octave) for note in notes]
+        return ", ".join(rendered_notes), rendered_notes, []
+
+    @staticmethod
+    def pair(
+        start: Note,
+        end: Note,
+        style: str = SPN_STYLE,
+        with_octave: bool = True,
+        interval_number: int | None = None,
+    ) -> str:
+        """Render an interval endpoint pair or full ABC harmonic interval."""
+        if style == FULL_ABC_SCORE_STYLE:
+            return ABCContext.interval_score(start, end, with_octave, interval_number)
+        return f"{NoteRenderer.note(start, style, with_octave)}-{NoteRenderer.note(end, style, with_octave)}"
+
+    @staticmethod
+    def notation_hint(style: str) -> str:
+        """Return a short prompt sentence naming the input note notation."""
+        if style == SPN_STYLE:
+            return "Notes are written in scientific pitch notation."
+        if style == COMPACT_ABC_STYLE:
+            return "Notes are written in compact ABC notation."
+        if style == FULL_ABC_SCORE_STYLE:
+            return "Notes are written as full ABC score fragments."
+        raise ValueError(f"Unsupported note rendering style: {style}")
+
+    @staticmethod
+    def answer_rendering(prompt_style: str) -> tuple[str, str, bool]:
+        """Return answer style, notation label, and explicit-natural policy."""
+        answer_style = SPN_STYLE if prompt_style == SPN_STYLE else COMPACT_ABC_STYLE
+        answer_notation = "scientific pitch notation" if answer_style == SPN_STYLE else "compact ABC notation"
+        force_natural = prompt_style == FULL_ABC_SCORE_STYLE
+        return answer_style, answer_notation, force_natural
+
+    @staticmethod
+    def answer_format(answer_notation: str, with_octave: bool | None = None, explicit_accidentals: bool = False) -> str:
+        """Return the prompt phrase describing an expected note-answer format."""
+        if answer_notation == "compact ABC notation" and with_octave:
+            answer_format = "one full compact ABC pitch token"
+            if explicit_accidentals:
+                answer_format += ", with any accidental made explicit"
+            return answer_format
+
+        octave_phrase = "" if with_octave is None else f" {'with' if with_octave else 'without'} octave"
+        answer_format = f"one note name{octave_phrase} in {answer_notation}"
+        if explicit_accidentals:
+            answer_format += ", with any accidental made explicit"
+        return answer_format
+
+
+class PromptFormatter:
+    """Prompt-formatting helpers shared by music task generators."""
+
+    @staticmethod
+    def options(labels: Sequence[str]) -> str:
+        """Render answer choices in a sampled order."""
+        return ", ".join(random.sample(list(labels), len(labels)))
+
+    @staticmethod
+    def notation_instruction(style: str) -> str:
+        """Return the prompt sentence for the sampled note notation."""
+        if style == FULL_ABC_SCORE_STYLE:
+            return "Interpret the score using its key signature."
+        return NoteRenderer.notation_hint(style)
+
+    @staticmethod
+    def choice_prompt(
+        opener_templates: Sequence[str],
+        tail_templates: Sequence[str],
+        style: str | None = None,
+        notation_separator: str = " ",
+        tail_separator: str = " ",
+        **values: object,
+    ) -> str:
+        """Compose a prompt from one sampled opener and one sampled answer-format tail."""
+        opener = random.choice(opener_templates).format(**values)
+        tail = random.choice(tail_templates).format(**values)
+        notation = f"{notation_separator}{PromptFormatter.notation_instruction(style)}" if style is not None else ""
+        return f"{opener}{notation}{tail_separator}{tail}"
+
+
+class Music21Adapter:
+    """Conversion helpers between task Note objects and music21 objects."""
+
+    @staticmethod
+    def chord(notes: Sequence[Note]) -> m21_chord.Chord:
+        """Convert task Note objects to a music21 Chord."""
+        return m21_chord.Chord([Music21Adapter.pitch_name(note) for note in notes])
+
+    @staticmethod
+    def note_from_pitch(pitch: Any, with_octave: bool = False) -> Note:
+        """Convert a music21 Pitch to the task's Note spelling."""
+        name = pitch.nameWithOctave if with_octave else pitch.name
+        return Note.parse(name.replace("-", "b"))
+
+    @staticmethod
+    def pitch_name(note: Note) -> str:
+        """Render a Note spelling in music21's flat notation."""
+        return note.name().replace("b", "-")
+
+
+@dataclass(frozen=True)
+class ChordRendering:
+    """Rendered chord text plus resolved note tokens for reasoning traces."""
+
+    prompt_text: str
+    cot_text: str
+    resolution_cot: list[str]
+
+
+class ChordRenderer:
+    """Rendering rules for chord-tone collections in prompt text and CoTs."""
+
+    @staticmethod
+    def join(rendered_notes: Sequence[str], sep: str = "-") -> str:
+        """Join rendered chord tones in the project's chord-list format."""
+        return sep.join(rendered_notes)
+
+    @staticmethod
+    def render(
+        notes: Sequence[Note],
+        style: str,
+        with_octave: bool = False,
+        shuffle: bool = True,
+        sep: str = "-",
+    ) -> ChordRendering:
+        """Render chord tones in SPN, compact ABC, or one full ABC chord score."""
+        ordered_notes = random.sample(list(notes), len(notes)) if shuffle else list(notes)
+        if style == FULL_ABC_SCORE_STYLE:
+            context = ABCContext.random()
+            rendered = [context.render_event(note, with_octave=with_octave) for note in ordered_notes]
+            chord_event = f"[{''.join(note.token for note in rendered)}]{ABCContext.duration_suffix()}"
+            resolved_notes = [
+                NoteRenderer.note(note.note, COMPACT_ABC_STYLE, force_natural=True)
+                for note in rendered
+            ]
+            return ChordRendering(
+                prompt_text=context.score_text([chord_event]),
+                cot_text=ChordRenderer.join(resolved_notes, sep),
+                resolution_cot=[context.resolution_sentence(note) for note in rendered],
+            )
+
+        rendered_notes = [
+            NoteRenderer.note(note, style, with_octave=with_octave)
+            for note in ordered_notes
+        ]
+        rendered_chord = ChordRenderer.join(rendered_notes, sep)
+        return ChordRendering(prompt_text=rendered_chord, cot_text=rendered_chord, resolution_cot=[])
+
+    @staticmethod
+    def for_cot(
+        notes: Sequence[Note],
+        style: str,
+        with_octave: bool = False,
+        sep: str = "-",
+    ) -> str:
+        """Render canonical chord order in the same notation family as the prompt."""
+        note_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        return ChordRenderer.join(
+            [
+                NoteRenderer.note(
+                    note,
+                    note_style,
+                    with_octave=with_octave,
+                    force_natural=style == FULL_ABC_SCORE_STYLE,
+                )
+                for note in notes
+            ],
+            sep,
+        )
+
+    @staticmethod
+    def prompt_value(rendering: ChordRendering, style: str) -> str:
+        """Return an inline chord value or a full-score chord reference."""
+        if style == FULL_ABC_SCORE_STYLE:
+            return f"the chord in this ABC score fragment:\n{rendering.prompt_text}"
+        return rendering.prompt_text
+
+
+class ChordTools:
+    """Small chord/spelling helpers shared by chord-like task generators."""
+
+    @staticmethod
+    def with_ascending_octaves(
+        notes: Sequence[Note],
+        min_root_octave: int = 1,
+        max_root_octave: int = 6,
+    ) -> list[Note]:
+        """Assign octaves so the given chord-tone order sounds upward."""
+        root_octave = random.randint(min_root_octave, max_root_octave)
+        voiced_notes = [Note(notes[0].letter, notes[0].accidental, root_octave)]
+        for note in notes[1:]:
+            octave = voiced_notes[-1].octave
+            voiced_note = Note(note.letter, note.accidental, octave)
+            while voiced_note.semitone_number <= voiced_notes[-1].semitone_number:
+                octave += 1
+                voiced_note = Note(note.letter, note.accidental, octave)
+            voiced_notes.append(voiced_note)
+        return voiced_notes
+
+    @staticmethod
+    def pitch_class_set(notes: Sequence[Note]) -> set[int]:
+        """Return the pitch-class set represented by a chord."""
+        return {note.pc for note in notes}
+
+    @staticmethod
+    def different_spelling_same_pitch(note: Note, accidental_limit: int) -> Note:
+        """Choose a different spelling for the same pitch when possible."""
+        spellings = [
+            spelling if note.octave is not None else spelling.without_octave()
+            for spelling in note.exact_pitch_spellings(accidental_limit)
+            if not note.same_spelling(spelling, include_octave=True)
+        ]
+        if not spellings:
+            return note
+        return random.choice(spellings)
+
+    @staticmethod
+    def close_voicing(root_position: Sequence[Note]) -> list[Note]:
+        """Return a compact voicing in one octave."""
+        return list(root_position)
+
+    @staticmethod
+    def open_voicing(root_position: Sequence[Note]) -> list[Note]:
+        """Return a deliberately open voicing with skipped chord members."""
+        root_octave = root_position[0].octave or 4
+        root_step = root_position[0].step
+        for _ in range(GENERATION_RETRY_LIMIT):
+            voiced_notes = [
+                Note(root_position[0].letter, root_position[0].accidental, root_octave)
+            ]
+            for index, note in enumerate(root_position[1:], start=1):
+                base_octave = note.octave
+                if base_octave is None:
+                    base_octave = root_octave + int(note.step < root_step and index > 0)
+                octave = base_octave + random.randint(0, 2)
+                voiced_notes.append(Note(note.letter, note.accidental, octave))
+            voiced_notes.sort(key=lambda note: note.semitone_number)
+            span = voiced_notes[-1].semitone_number - voiced_notes[0].semitone_number
+            if span > 12 and ChordTools.skips_chord_member(voiced_notes, root_position):
+                return voiced_notes
+
+        if len(root_position) == 3:
+            root, third, fifth = root_position
+            return [
+                Note(root.letter, root.accidental, root_octave),
+                Note(fifth.letter, fifth.accidental, root_octave + 1),
+                Note(third.letter, third.accidental, root_octave + 2),
+            ]
+        root, third, fifth, seventh = root_position
+        return [
+            Note(root.letter, root.accidental, root_octave),
+            Note(fifth.letter, fifth.accidental, root_octave + 1),
+            Note(third.letter, third.accidental, root_octave + 2),
+            Note(seventh.letter, seventh.accidental, root_octave + 3),
+        ]
+
+    @staticmethod
+    def skips_chord_member(voicing: Sequence[Note], root_position: Sequence[Note]) -> bool:
+        """Return whether adjacent voiced notes skip over an available chord tone."""
+        voice_numbers = sorted(note.semitone_number for note in voicing)
+        voice_number_set = set(voice_numbers)
+        min_octave = min(note.octave for note in voicing if note.octave is not None) - 1
+        max_octave = max(note.octave for note in voicing if note.octave is not None) + 1
+        member_numbers = {
+            Note(member.letter, member.accidental, octave).semitone_number
+            for member in root_position
+            for octave in range(min_octave, max_octave + 1)
+        }
+        skipped_member_numbers = member_numbers - voice_number_set
+        return any(
+            any(lower < member_number < upper for member_number in skipped_member_numbers)
+            for lower, upper in zip(voice_numbers, voice_numbers[1:])
+        )
+
+
+class TextFormatter:
+    """Small text-formatting helpers used when composing prompts and CoTs."""
+
+    @staticmethod
+    def article(phrase: str) -> str:
+        """Return a phrase prefixed with the appropriate indefinite article."""
+        phrase = phrase.strip()
+        if not phrase:
+            raise ValueError("Cannot add an article to an empty phrase.")
+
+        lower = phrase.lower()
+        first_word = lower.split(maxsplit=1)[0]
+        starts_with_vowel_sound = lower[0] in "aeio" and not lower.startswith(("uni", "use", "eu"))
+        starts_with_letter_name = first_word in {"f", "l", "m", "n", "r", "s", "x"}
+        use_an = starts_with_vowel_sound or starts_with_letter_name
+        return f"{'an' if use_an else 'a'} {phrase}"
+
+    @staticmethod
+    def capitalize_initial(text: str) -> str:
+        """Capitalize only the first character, preserving the rest of the text."""
+        # Python’s built-in .capitalize() also lowercases the rest of the string.
+        return text[:1].upper() + text[1:]
+
+    @staticmethod
+    def count_phrase(count: int, word: str = "semitone", plural: str | None = None) -> str:
+        """Format a count with a simple plural suffix."""
+        if count == 1:
+            return f"{count} {word}"
+        return f"{count} {plural or word + 's'}"

--- a/reasoning_core/tasks/chord_roman_reasoning.py
+++ b/reasoning_core/tasks/chord_roman_reasoning.py
@@ -1,0 +1,1215 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+import random
+from typing import Any
+
+from music21 import key as m21_key
+from music21 import roman as m21_roman
+
+from reasoning_core.template import Config, Problem, Task, edict
+from reasoning_core.tasks._music_theory import (
+    AnswerNormalizer,
+    CHOICE_TAILS,
+    COMPACT_ABC_STYLE,
+    FULL_ABC_SCORE_SHARE,
+    FULL_ABC_SCORE_STYLE,
+    GENERATION_RETRY_LIMIT,
+    ChordRenderer,
+    ChordTools,
+    Interval,
+    Music21Adapter,
+    Note,
+    NoteRenderer,
+    PromptFormatter,
+    Scale,
+    SPN_STYLE,
+    TextFormatter,
+    YES_NO_TAILS,
+    key_tonics,
+)
+
+
+TRIAD_QUALITIES = (
+    "major triad",
+    "minor triad",
+    "diminished triad",
+    "augmented triad",
+)
+SEVENTH_CHORD_QUALITIES = (
+    "major seventh",
+    "dominant seventh",
+    "minor seventh",
+    "half-diminished seventh",
+    "fully diminished seventh",
+    "minor-major seventh",
+    "augmented-major seventh",
+)
+CHORD_QUALITIES = TRIAD_QUALITIES + SEVENTH_CHORD_QUALITIES
+INVERSION_LABELS = {
+    3: (
+        ("root position", "5/3"),
+        ("first inversion", "6"),
+        ("second inversion", "6/4"),
+    ),
+    4: (
+        ("root position", "7"),
+        ("first inversion", "6/5"),
+        ("second inversion", "4/3"),
+        ("third inversion", "4/2"),
+    ),
+}
+CHROMATIC_CHORDS = (
+    ("Neapolitan sixth", "N6"),
+    ("Italian augmented sixth", "It6"),
+    ("French augmented sixth", "Fr43"),
+    ("German augmented sixth", "Ger65"),
+    ("Swiss augmented sixth", "Sw43"),
+)
+CHROMATIC_SCALE_DEGREE_FORMULAS = {
+    "Neapolitan sixth": "4-b6-b2",
+    "Italian augmented sixth": "b6-1-#4",
+    "French augmented sixth": "b6-1-2-#4",
+    "German augmented sixth": "b6-1-b3-#4",
+    "Swiss augmented sixth": "b6-1-#2-#4",
+}
+MODE_NAMES = (
+    "chord_quality",
+    "inversion",
+    "open_close_voicing",
+    "enharmonic_chord_equivalence",
+    "chromatic_chord_label",
+    "chord_membership",
+    "roman_numeral_from_chord",
+    "chord_from_roman_numeral",
+)
+
+QUALITY_OPENERS = (
+    "What is the quality of {chord} as a chord-tone collection?",
+    "Classify {chord} as a chord-tone collection.",
+    "Identify the quality of {chord} as chord tones.",
+    "Name the quality of {chord} as a chord-tone collection.",
+)
+INVERSION_OPENERS = (
+    "Treat {chord} as an unordered collection of chord tones; the bass note is {bass}.",
+    "Use {chord} as the chord-tone collection, with {bass} as the bass note.",
+    "Given {chord} as the chord-tone collection with {bass} in the bass, identify the inversion.",
+    "Analyze the inversion of {chord} as a chord-tone collection when {bass} is the bass note.",
+    "Use {chord} as the unordered chord tones; the bass is {bass}.",
+    "For {chord} as unordered chord tones, find the inversion over bass note {bass}.",
+)
+INVERSION_TAILS = (
+    "The answer is one inversion label followed by figured bass.",
+    "Give one inversion label followed by figured bass.",
+    "The expected answer is an inversion label plus figured bass.",
+    "Answer with the inversion label and figured-bass symbol.",
+)
+OPEN_CLOSE_VOICING_OPENERS = (
+    "{chord} is in which voicing?",
+    "Classify the voicing of {chord}.",
+    "Is {chord} in open or close voicing?",
+    "Determine the voicing type of {chord}.",
+    "For {chord}, identify the voicing.",
+    "Label the voicing of {chord}.",
+    "What voicing label applies to {chord}?",
+    "Decide whether {chord} is in open or close voicing.",
+)
+CHROMATIC_COLLECTION_OPENERS = (
+    "In {key}, label {chord} as a chord-tone collection with {bass} in the bass.",
+    "In {key}, identify the chromatic label for {chord} as a chord-tone collection with bass {bass}.",
+    "Analyze {chord} as a chromatic chord-tone collection with {bass} in the bass in {key}.",
+    "For {key}, choose the label for {chord} as a chord-tone collection with bass {bass}.",
+    "In the key of {key}, classify {chord} as a chord-tone collection with bass note {bass}.",
+    "Using {key}, name the chromatic chord-tone collection represented by {chord} with {bass} in the bass.",
+    "In {key}, what chromatic label fits {chord} as a chord-tone collection with bass {bass}?",
+    "Given {key}, label {chord} as a chord-tone collection with bass {bass}.",
+)
+CHROMATIC_ORDERED_OPENERS = (
+    "In {key}, label {chord}.",
+    "In {key}, identify the chromatic label for {chord}.",
+    "Analyze {chord} in {key}.",
+    "For {key}, choose the label for {chord}.",
+    "In the key of {key}, classify {chord}.",
+    "Using {key}, name {chord} as a chromatic sonority.",
+    "In {key}, what chromatic label fits {chord}?",
+    "Given {key}, label {chord}.",
+)
+MEMBERSHIP_OPENERS = (
+    "Is {chord} diatonic in {key}?",
+    "Do all tones of {chord} belong to {key}?",
+    "In {key}, is {chord} a diatonic chord?",
+    "Check whether {chord} is diatonic in {key}.",
+    "Does {chord} use only notes from {key}?",
+    "For {key}, decide whether {chord} is diatonic.",
+    "Classify membership: is {chord} inside {key}?",
+    "Does {chord} fit {key} as a collection of chord tones?",
+    "Is every note of {chord} contained in {key}?",
+    "In the collection {key}, does {chord} stay diatonic?",
+    "Determine whether {chord} is diatonic to {key}.",
+    "For the key context {key}, test {chord}.",
+)
+ROMAN_FROM_COLLECTION_OPENERS = (
+    "In {key}, treat {chord} as a chord-tone collection with {bass} in the bass.",
+    "Give the Roman numeral for {chord} as a chord-tone collection with {bass} in the bass in {key}.",
+    "In {key}, identify the Roman numeral of {chord} as chord tones over bass {bass}.",
+    "Analyze {chord} as chord tones over bass {bass} in {key}.",
+    "For {key}, what Roman numeral describes {chord} as a chord-tone collection with bass {bass}?",
+    "Using {key}, label {chord} as chord tones with {bass} in the bass.",
+    "In the key of {key}, Roman-numeral analyze {chord} as chord tones over {bass}.",
+    "Find the compact Roman numeral for {chord} as a chord-tone collection with bass note {bass} in {key}.",
+)
+ROMAN_FROM_ORDERED_OPENERS = (
+    "In {key}, analyze {chord}.",
+    "Give the Roman numeral for {chord} in {key}.",
+    "In {key}, identify the Roman numeral of {chord}.",
+    "Analyze {chord} in {key}.",
+    "For {key}, what Roman numeral describes {chord}?",
+    "Using {key}, label {chord} as a Roman numeral.",
+    "In the key of {key}, Roman-numeral analyze {chord}.",
+    "Find the compact Roman numeral for {chord} in {key}.",
+)
+ROMAN_TAILS = (
+    "The answer is one compact Roman numeral with figured-bass digits closed up.",
+    "Give one compact Roman numeral, closing up figured-bass digits.",
+    "The expected answer is a compact Roman numeral with no internal spaces.",
+    "Answer with one compact Roman numeral and closed-up figured bass.",
+)
+CHORD_FROM_ROMAN_OPENERS = (
+    "In {key}, spell {figure}.",
+    "Spell the chord for {figure} in {key}.",
+    "In {key}, give the chord tones for {figure}.",
+    "Which chord tones does {figure} produce in {key}?",
+    "For {key}, spell the Roman numeral {figure}.",
+    "Using {key}, list the chord tones of {figure}.",
+    "In the key of {key}, realize {figure} as chord tones.",
+    "Write the notes produced by {figure} in {key}.",
+)
+NOTE_SEQUENCE_TAILS = (
+    "The answer is hyphen-separated note names from bass upward in {answer_notation}.",
+    "Give hyphen-separated note names from bass upward in {answer_notation}.",
+    "The expected answer is a bass-upward note sequence in {answer_notation}, separated by hyphens.",
+    "Answer with note names from bass upward in {answer_notation}, separated by hyphens.",
+)
+ENHARMONIC_OPENERS = (
+    "Are {first} and {second} enharmonically equivalent as pitch-class chords?",
+    "Do {first} and {second} represent the same pitch-class chord?",
+    "Compare {first} and {second}: are they enharmonically equivalent pitch-class chords?",
+    "Are the pitch-class contents of {first} and {second} enharmonically equivalent?",
+    "Do {first} and {second} represent the same pitch-class set?",
+    "Check whether {first} and {second} are enharmonically equivalent as pitch-class chords.",
+    "Are {first} and {second} equivalent after reducing to pitch classes?",
+    "Do {first} and {second} have matching pitch-class sets?",
+)
+
+
+TRIAD_INTERVALS = {
+    "major triad": (("major", 3), ("perfect", 5)),
+    "minor triad": (("minor", 3), ("perfect", 5)),
+    "diminished triad": (("minor", 3), ("diminished", 5)),
+    "augmented triad": (("major", 3), ("augmented", 5)),
+}
+SEVENTH_INTERVALS = {
+    "major seventh": (("major", 3), ("perfect", 5), ("major", 7)),
+    "dominant seventh": (("major", 3), ("perfect", 5), ("minor", 7)),
+    "minor seventh": (("minor", 3), ("perfect", 5), ("minor", 7)),
+    "half-diminished seventh": (("minor", 3), ("diminished", 5), ("minor", 7)),
+    "fully diminished seventh": (("minor", 3), ("diminished", 5), ("diminished", 7)),
+    "minor-major seventh": (("minor", 3), ("perfect", 5), ("major", 7)),
+    "augmented-major seventh": (("major", 3), ("augmented", 5), ("major", 7)),
+}
+ROMAN_MAJOR_TRIADS = ("I", "ii", "iii", "IV", "V", "vi", "viio")
+ROMAN_MAJOR_SEVENTHS = ("I7", "ii7", "iii7", "IV7", "V7", "vi7", "vii/o7")
+ROMAN_MINOR_TRIADS = ("i", "iio", "III", "iv", "V", "VI", "viio")
+ROMAN_MINOR_SEVENTHS = ("i7", "ii/o7", "III7", "iv7", "V7", "VI7", "viio7")
+ROMAN_MAJOR_SECONDARY_TRIADS = (
+    "V/ii",
+    "V/iii",
+    "V/IV",
+    "V/V",
+    "V/vi",
+    "viio/ii",
+    "viio/iii",
+    "viio/IV",
+    "viio/V",
+    "viio/vi",
+)
+ROMAN_MAJOR_SECONDARY_SEVENTHS = (
+    "V7/ii",
+    "V7/iii",
+    "V7/IV",
+    "V7/V",
+    "V7/vi",
+    "viio7/ii",
+    "viio7/iii",
+    "viio7/IV",
+    "viio7/V",
+    "viio7/vi",
+)
+ROMAN_MINOR_SECONDARY_TRIADS = (
+    "V/III",
+    "V/iv",
+    "V/V",
+    "V/VI",
+    "V/VII",
+    "viio/III",
+    "viio/iv",
+    "viio/V",
+    "viio/VI",
+    "viio/VII",
+)
+ROMAN_MINOR_SECONDARY_SEVENTHS = (
+    "V7/III",
+    "V7/iv",
+    "V7/V",
+    "V7/VI",
+    "V7/VII",
+    "viio7/III",
+    "viio7/iv",
+    "viio7/V",
+    "viio7/VI",
+    "viio7/VII",
+)
+TRIAD_INVERSION_SUFFIXES = ("", "6", "64")
+SEVENTH_INVERSION_SUFFIXES = ("7", "65", "43", "42")
+
+
+@dataclass
+class ChordRomanConfig(Config):
+    """Configuration knobs for chord and Roman-numeral reasoning."""
+
+    # Which generation mode to use. "any" samples uniformly among all supported modes.
+    mode: str = "any"
+
+    # Probability of sampling a seventh chord instead of a triad in modes that
+    # can use either size. Triads and seventh chords remain possible at every level.
+    p_seventh: float = 0.30
+
+    # Maximum accidental complexity for generated chord spellings.
+    max_accidental: int = 1
+
+    # Maximum number of sharps/flats in analytical key signatures.
+    key_complexity: int = 2
+
+    # Probability of secondary/applied Roman material where the mode allows it.
+    p_secondary: float = 0.10
+
+    # Probability of writing prompt/answer notes in ABC notation instead of
+    # scientific pitch notation. ABC examples are split into 70% compact note
+    # tokens and 30% full score fragments with sampled common L/M/K headers.
+    p_abc: float = 0.20
+
+    # Maximum attempts to generate a valid instance before failing.
+    max_tries: int = 256
+
+    # Override of Config.update; called by Config.set_level() to raise difficulty.
+    def update(self, c: float = 1) -> None:
+        """Increase generation difficulty by updating monotonic config knobs."""
+        self.p_seventh = min(0.60, self.p_seventh + 0.06 * c)
+        self.max_accidental = min(2, self.max_accidental + 0.2 * c)
+        self.key_complexity = min(7, self.key_complexity + c)
+        self.p_secondary = min(0.70, self.p_secondary + 0.08 * c)
+        self.p_abc = min(0.50, self.p_abc + 0.06 * c)
+
+    def random_style(self) -> str:
+        """Sample the note-rendering style for a prompt."""
+        roll = random.random()
+        if roll < FULL_ABC_SCORE_SHARE * self.p_abc:
+            return FULL_ABC_SCORE_STYLE
+        if roll < self.p_abc:
+            return COMPACT_ABC_STYLE
+        return SPN_STYLE
+
+
+class ChordRomanReasoning(Task):
+    """Procedural generator for chord quality, inversion, and Roman-numeral tasks."""
+
+    # Override of Task.__init__; keeps the normal task setup and adjusts balancing.
+    def __init__(self, config: ChordRomanConfig = ChordRomanConfig()) -> None:
+        """Initialize the task and reduce repeats for small label spaces."""
+        super().__init__(config=config)
+        # The default 0.5 allows too many repeats for low-cardinality modes
+        # such as yes/no equivalence and fixed-label chord-quality tasks.
+        self.balancing_key_ratio = 0.3
+
+    def _sample_mode(self) -> str:
+        """Choose a concrete generation mode from the configured mode setting."""
+        if self.config.mode != "any":
+            if self.config.mode not in MODE_NAMES:
+                raise ValueError(f"Unknown chord Roman mode: {self.config.mode}")
+            return self.config.mode
+        return random.choice(MODE_NAMES)
+
+    # Override of Task.generate; returns one generated Problem.
+    def generate(self) -> Problem:
+        """Generate one chord/Roman reasoning problem."""
+        mode = self._sample_mode()
+        for _ in range(self.config.max_tries):
+            try:
+                # Dispatch by convention: "chord_quality" -> self._generate_chord_quality().
+                return getattr(self, f"_generate_{mode}")()
+            except (KeyError, ValueError, m21_roman.RomanNumeralException):
+                continue
+        raise RuntimeError(f"Failed to generate a chord_roman_reasoning instance for mode {mode!r}.")
+
+    # Override of Task.prompt; prompt text is already stored in metadata.
+    def prompt(self, metadata: Any) -> str:
+        """Return the prompt string stored in generated metadata."""
+        return metadata.prompt
+
+    # Override of Task.score_answer; normalizes chord/Roman-specific answer formats.
+    def score_answer(self, answer: object, entry: Problem) -> float:
+        """Score an answer after normalizing chord/Roman answer formats."""
+        expected = str(entry.answer)
+        kind = entry.metadata.get("answer_kind", "text")
+        if kind == "yes_no":
+            return float(AnswerNormalizer.text(answer) == expected)
+        if kind == "roman":
+            return float(AnswerNormalizer.roman(answer) == AnswerNormalizer.roman(expected))
+        if kind == "note_sequence":
+            answer_notation = entry.metadata.get("answer_notation")
+            return float(
+                AnswerNormalizer.note_sequence(answer, answer_notation)
+                == AnswerNormalizer.note_sequence(expected, answer_notation)
+            )
+        return float(AnswerNormalizer.text(answer) == AnswerNormalizer.text(expected))
+
+    # Override of Task.balancing_key; limits repeats of the same mode-answer pair.
+    def balancing_key(self, problem: Problem) -> str:
+        """Return the batch-balancing key for this generated problem."""
+        return f"{problem.metadata.mode}:{problem.answer}"
+
+    def _problem(
+        self,
+        mode: str,
+        prompt: str,
+        answer: object,
+        answer_kind: str,
+        cot: Sequence[str],
+        **metadata: Any,
+    ) -> Problem:
+        """Package prompt, answer, reasoning trace, and metadata as a Problem."""
+        meta = edict(mode=mode, prompt=prompt, answer_kind=answer_kind, cot="\n".join(cot), **metadata)
+        return Problem(metadata=meta, answer=str(answer))
+    
+    def _generate_chord_quality(self) -> Problem:
+        """Generate a task asking for a triad or seventh-chord quality label."""
+        style = self.config.random_style()
+        size = self._sample_chord_size()
+        interval_table = SEVENTH_INTERVALS if size == 4 else TRIAD_INTERVALS
+        notes, quality = self._sample_chord(interval_table)
+        rendered = ChordRenderer.render(notes, style)
+        interval_names = [
+            Interval(interval_quality, number).name()
+            for interval_quality, number in interval_table[quality]
+        ]
+        note_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        root = notes[0]
+        rendered_root = NoteRenderer.note(root, note_style, force_natural=style == FULL_ABC_SCORE_STYLE)
+        rendered_upper_notes = [
+            NoteRenderer.note(note, note_style, force_natural=style == FULL_ABC_SCORE_STYLE)
+            for note in notes[1:]
+        ]
+        prompt = PromptFormatter.choice_prompt(
+            QUALITY_OPENERS,
+            CHOICE_TAILS,
+            style=style,
+            chord=ChordRenderer.prompt_value(rendered, style),
+            options=PromptFormatter.options(CHORD_QUALITIES),
+        )
+        interval_phrases = [
+            f"from {rendered_root} to {rendered_note} is {TextFormatter.article(interval_name)}"
+            for rendered_note, interval_name in zip(rendered_upper_notes, interval_names)
+        ]
+        article_intervals = [TextFormatter.article(interval_name) for interval_name in interval_names]
+        if len(article_intervals) == 2:
+            interval_summary = " and ".join(article_intervals)
+        else:
+            interval_summary = f"{', '.join(article_intervals[:-1])}, and {article_intervals[-1]}"
+        chord_kind = "seventh chord" if size == 4 else "triad"
+        cot = rendered.resolution_cot + [
+            f"Arrange the chord tones by stacking thirds to get the root-position chord "
+            f"{ChordRenderer.for_cot(notes, style)}, with {rendered_root} as the root.",
+            f"The intervals above the root are: {', '.join(interval_phrases)}.",
+            f"A {chord_kind} with {interval_summary} above the root is {TextFormatter.article(quality)}.",
+        ]
+        return self._problem(
+            "chord_quality",
+            prompt,
+            quality,
+            "label",
+            cot,
+            chord_notes=[note.name(False) for note in notes],
+            style=style,
+        )
+
+    def _generate_inversion(self) -> Problem:
+        """Generate a task asking for inversion label plus figured bass."""
+        style = self.config.random_style()
+        size = self._sample_chord_size()
+        interval_table = SEVENTH_INTERVALS if size == 4 else TRIAD_INTERVALS
+        notes, quality = self._sample_chord(interval_table)
+        inversion = random.randint(0, size - 1)
+        bass = notes[inversion]
+        rendered = ChordRenderer.render(notes, style)
+        rendered_bass = NoteRenderer.note(
+            bass,
+            COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style,
+            force_natural=style == FULL_ABC_SCORE_STYLE,
+        )
+        inversion_label, figured_bass = INVERSION_LABELS[size][inversion]
+        answer = f"{inversion_label} {figured_bass}"
+        prompt = PromptFormatter.choice_prompt(
+            INVERSION_OPENERS,
+            INVERSION_TAILS,
+            style=style,
+            chord=ChordRenderer.prompt_value(rendered, style),
+            bass=rendered_bass,
+        )
+        cot = rendered.resolution_cot + [
+            f"Arrange the chord tones by stacking thirds to get the root-position chord "
+            f"{ChordRenderer.for_cot(notes, style)}, {TextFormatter.article(quality)}.",
+            f"The bass note {rendered_bass} is chord member {inversion + 1} above the root.",
+            f"For a {size}-note chord, that gives {answer}.",
+        ]
+        return self._problem(
+            "inversion",
+            prompt,
+            answer,
+            "text",
+            cot,
+            chord_notes=[note.name(False) for note in notes],
+            bass_note=bass.name(False),
+            style=style,
+        )
+
+    def _generate_open_close_voicing(self) -> Problem:
+        """Generate a task classifying a voiced chord as open or close voicing."""
+        style = self.config.random_style()
+        size = self._sample_chord_size()
+        interval_table = SEVENTH_INTERVALS if size == 4 else TRIAD_INTERVALS
+        use_close = random.choice([True, False])
+        root_position, quality = self._sample_chord(
+            interval_table,
+            with_octave=True,
+            min_root_octave=1,
+            max_root_octave=6 if use_close else 4,
+        )
+        voiced_notes = (
+            ChordTools.close_voicing(root_position)
+            if use_close
+            else ChordTools.open_voicing(root_position)
+        )
+        answer = "close voicing" if use_close else "open voicing"
+        rendered = ChordRenderer.render(voiced_notes, style, with_octave=True, shuffle=False)
+        prompt = PromptFormatter.choice_prompt(
+            OPEN_CLOSE_VOICING_OPENERS,
+            CHOICE_TAILS,
+            style=style,
+            chord=ChordRenderer.prompt_value(rendered, style),
+            options=PromptFormatter.options(("open voicing", "close voicing")),
+        )
+        span = max(note.semitone_number for note in voiced_notes) - min(
+            note.semitone_number for note in voiced_notes
+        )
+        cot = rendered.resolution_cot + [
+            f"The voiced chord is {rendered.cot_text}, {TextFormatter.article(quality)}.",
+            f"The outer notes span {TextFormatter.count_phrase(span)}.",
+            (
+                "The chord tones fit within one octave without skipping a chord member between adjacent upper notes."
+                if use_close
+                else "At least one adjacent pair skips over another chord member, so the voicing is open."
+            ),
+            f"So the answer is {answer}.",
+        ]
+        return self._problem(
+            "open_close_voicing",
+            prompt,
+            answer,
+            "label",
+            cot,
+            chord_notes=[note.name() for note in voiced_notes],
+            style=style,
+        )
+
+    def _generate_enharmonic_chord_equivalence(self) -> Problem:
+        """Generate a task comparing two chords by pitch-class equivalence."""
+        style = self.config.random_style()
+        with_octave = random.choice([False, True])
+        size = self._sample_chord_size()
+        interval_table = SEVENTH_INTERVALS if size == 4 else TRIAD_INTERVALS
+        first, _ = self._sample_chord(interval_table, with_octave=True)
+        yes = random.choice([True, False])
+        max_accidental = self.config.max_accidental
+        if yes:
+            second = [
+                ChordTools.different_spelling_same_pitch(note, max_accidental)
+                for note in first
+            ]
+        else:
+            for _ in range(GENERATION_RETRY_LIMIT):
+                second, _ = self._sample_chord(interval_table, with_octave=True)
+                if ChordTools.pitch_class_set(second) != ChordTools.pitch_class_set(first):
+                    break
+            else:
+                raise ValueError("Could not construct a non-equivalent chord pair.")
+        answer = "yes" if yes else "no"
+        rendered_first = ChordRenderer.render(
+            first,
+            style,
+            with_octave=with_octave,
+            shuffle=not with_octave,
+        )
+        rendered_second = ChordRenderer.render(
+            second,
+            style,
+            with_octave=with_octave,
+            shuffle=not with_octave,
+        )
+        prompt = PromptFormatter.choice_prompt(
+            ENHARMONIC_OPENERS,
+            YES_NO_TAILS,
+            style=style,
+            first=ChordRenderer.prompt_value(rendered_first, style),
+            second=ChordRenderer.prompt_value(rendered_second, style),
+        )
+        cot = rendered_first.resolution_cot + rendered_second.resolution_cot + [
+            f"The first chord has pitch classes {sorted(ChordTools.pitch_class_set(first))}.",
+            f"The second chord has pitch classes {sorted(ChordTools.pitch_class_set(second))}.",
+            (
+                "The pitch-class sets match, so the answer is yes."
+                if yes
+                else "The pitch-class sets differ, so the answer is no."
+            ),
+        ]
+        return self._problem(
+            "enharmonic_chord_equivalence",
+            prompt,
+            answer,
+            "yes_no",
+            cot,
+            first_chord=[note.name(with_octave) for note in first],
+            second_chord=[note.name(with_octave) for note in second],
+            style=style,
+            with_octave=with_octave,
+        )
+
+    def _generate_chromatic_chord_label(self) -> Problem:
+        """Generate a task labeling Neapolitan or augmented-sixth chords."""
+        style = self.config.random_style()
+        with_octave = random.choice([False, True])
+        label, figure, tonic, mode, rn, notes = self._sample_chromatic_chord(with_octave)
+        bass = Music21Adapter.note_from_pitch(rn.bass(), with_octave=with_octave)
+        rendered = ChordRenderer.render(
+            notes,
+            style,
+            with_octave=with_octave,
+            shuffle=not with_octave,
+        )
+        rendered_bass = NoteRenderer.note(
+            bass,
+            COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style,
+            with_octave=with_octave,
+            force_natural=style == FULL_ABC_SCORE_STYLE,
+        )
+        scale_degree_formula = self._scale_degree_formula(notes, tonic)
+        if scale_degree_formula != CHROMATIC_SCALE_DEGREE_FORMULAS[label]:
+            raise ValueError("Chromatic chord formula does not match its label.")
+        prompt = PromptFormatter.choice_prompt(
+            CHROMATIC_ORDERED_OPENERS if with_octave else CHROMATIC_COLLECTION_OPENERS,
+            CHOICE_TAILS,
+            style=style,
+            key=f"{tonic} {mode}",
+            chord=ChordRenderer.prompt_value(rendered, style),
+            bass=rendered_bass,
+            options=PromptFormatter.options(tuple(label for label, _ in CHROMATIC_CHORDS)),
+        )
+        cot = rendered.resolution_cot + [
+            f"Relative to tonic {tonic}, the scale-degree formula is {scale_degree_formula}.",
+            f"The formula {scale_degree_formula} identifies {TextFormatter.article(label)}.",
+        ]
+        if not with_octave:
+            cot.insert(
+                len(rendered.resolution_cot),
+                f"Arrange the chord tones from the specified bass upward as "
+                f"{ChordRenderer.for_cot(notes, style, with_octave)}.",
+            )
+        return self._problem(
+            "chromatic_chord_label",
+            prompt,
+            label,
+            "label",
+            cot,
+            key=f"{tonic} {mode}",
+            roman_figure=figure,
+            chord_notes=[note.name(with_octave) for note in notes],
+            bass_note=bass.name(with_octave),
+            style=style,
+            with_octave=with_octave,
+        )
+
+    def _generate_chord_membership(self) -> Problem:
+        """Generate a task asking whether a chord is diatonic in a key."""
+        style = self.config.random_style()
+        with_octave = random.choice([False, True])
+        max_accidental = self.config.max_accidental
+        scale, key_label = self._sample_scale()
+        yes = random.choice([True, False])
+        notes = self._sample_diatonic_chord(scale, self._sample_chord_size())
+        if not yes:
+            index = random.randrange(len(notes))
+            notes[index] = scale.alter_note_outside(notes[index], max_accidental)
+        answer = "yes" if all(scale.contains(note) for note in notes) else "no"
+        rendered_notes = ChordTools.with_ascending_octaves(notes) if with_octave else notes
+        rendered = ChordRenderer.render(
+            rendered_notes,
+            style,
+            with_octave=with_octave,
+            shuffle=not with_octave,
+            sep=", ",
+        )
+        prompt = PromptFormatter.choice_prompt(
+            MEMBERSHIP_OPENERS,
+            YES_NO_TAILS,
+            style=style,
+            chord=ChordRenderer.prompt_value(rendered, style),
+            key=f"{scale.tonic.name(False)} {key_label}",
+        )
+        scale_note_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        scale_notes = ", ".join(
+            NoteRenderer.note(
+                note,
+                scale_note_style,
+                force_natural=style == FULL_ABC_SCORE_STYLE,
+            )
+            for note in scale.degrees
+        )
+        cot_chord_notes = ChordRenderer.for_cot(notes, style, with_octave=False, sep=", ")
+        cot = rendered.resolution_cot + [
+            f"The {scale.tonic.name(False)} {key_label} collection is {scale_notes}.",
+            f"The chord tones are {cot_chord_notes}.",
+            (
+                "Every chord tone belongs to the collection, so the answer is yes."
+                if answer == "yes"
+                else "At least one chord tone is outside the collection, so the answer is no."
+            ),
+        ]
+        return self._problem(
+            "chord_membership",
+            prompt,
+            answer,
+            "yes_no",
+            cot,
+            key=f"{scale.tonic.name(False)} {key_label}",
+            chord_notes=[note.name(with_octave) for note in rendered_notes],
+            style=style,
+            with_octave=with_octave,
+        )
+
+    def _generate_roman_numeral_from_chord(self) -> Problem:
+        """Generate a task asking for Roman-numeral analysis of a chord in key."""
+        style = self.config.random_style()
+        with_octave = random.choice([False, True])
+        tonic, mode, rn, notes = self._sample_roman_context(with_octave)
+        bass = Music21Adapter.note_from_pitch(rn.bass(), with_octave=with_octave)
+        answer = AnswerNormalizer.roman(rn.figure)
+        rendered = ChordRenderer.render(
+            notes,
+            style,
+            with_octave=with_octave,
+            shuffle=not with_octave,
+        )
+        rendered_bass = NoteRenderer.note(
+            bass,
+            COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style,
+            with_octave=with_octave,
+            force_natural=style == FULL_ABC_SCORE_STYLE,
+        )
+        prompt = PromptFormatter.choice_prompt(
+            ROMAN_FROM_ORDERED_OPENERS if with_octave else ROMAN_FROM_COLLECTION_OPENERS,
+            ROMAN_TAILS,
+            style=style,
+            key=f"{tonic} {mode}",
+            chord=ChordRenderer.prompt_value(rendered, style),
+            bass=rendered_bass,
+        )
+        cot = rendered.resolution_cot + self._roman_analysis_cot(
+            notes,
+            bass,
+            rn,
+            answer,
+            tonic,
+            mode,
+            style,
+            rendered_bass,
+        )
+        return self._problem(
+            "roman_numeral_from_chord",
+            prompt,
+            answer,
+            "roman",
+            cot,
+            key=f"{tonic} {mode}",
+            chord_notes=[note.name(with_octave) for note in notes],
+            bass_note=bass.name(with_octave),
+            roman_figure=answer,
+            style=style,
+            with_octave=with_octave,
+        )
+
+    def _roman_analysis_cot(
+        self,
+        notes: Sequence[Note],
+        bass: Note,
+        rn: m21_roman.RomanNumeral,
+        answer: str,
+        tonic: str,
+        mode: str,
+        style: str,
+        rendered_bass: str,
+    ) -> list[str]:
+        """Explain how a chord and bass imply a Roman numeral in the key."""
+        root = Music21Adapter.note_from_pitch(rn.root()).without_octave()
+        root_position_notes = self._root_position_order(notes, root)
+        root_position_text = ChordRenderer.for_cot(root_position_notes, style, with_octave=False)
+        root_text = self._render_cot_note(root, style)
+        interval_phrases = self._roman_interval_phrases(root_position_notes, style)
+        quality = rn.commonName
+        size = len(root_position_notes)
+        inversion = self._bass_member_index(root_position_notes, bass)
+        suffix = self._roman_suffix(size, inversion)
+        base = self._roman_base(answer, suffix)
+        member_name = ("root", "third", "fifth", "seventh")[inversion]
+        inversion_label = INVERSION_LABELS[size][inversion][0]
+
+        cot = [
+            f"Arrange the chord tones by stacking thirds: {root_position_text}. The root is {root_text}.",
+            f"The intervals above the root are: {interval_phrases}. Therefore, the chord is {TextFormatter.article(quality)}.",
+            self._roman_function_sentence(base, root, quality, tonic, mode, style),
+            (
+                f"The bass {rendered_bass} is the chordal {member_name}, so the chord is in "
+                f"{inversion_label} and {self._roman_suffix_phrase(suffix, size)}."
+            ),
+            self._roman_combination_sentence(base, suffix, answer),
+        ]
+        return cot
+
+    def _generate_chord_from_roman_numeral(self) -> Problem:
+        """Generate a task asking for chord spelling from a Roman numeral."""
+        style = self.config.random_style()
+        tonic, mode, rn, notes = self._sample_roman_context()
+        answer_style, answer_notation, force_answer_natural = NoteRenderer.answer_rendering(style)
+        answer_notation_detail = answer_notation
+        if force_answer_natural:
+            answer_notation_detail += ", with any accidental made explicit"
+        answer = ChordRenderer.join(
+            [
+                NoteRenderer.note(
+                    note,
+                    answer_style,
+                    force_natural=force_answer_natural,
+                    quote_abc=False,
+                )
+                for note in notes
+            ]
+        )
+        rendered_answer = ChordRenderer.join(
+            [
+                NoteRenderer.note(note, answer_style, force_natural=force_answer_natural)
+                for note in notes
+            ]
+        )
+        prompt = PromptFormatter.choice_prompt(
+            CHORD_FROM_ROMAN_OPENERS,
+            NOTE_SEQUENCE_TAILS,
+            key=f"{tonic} {mode}",
+            figure=AnswerNormalizer.roman(rn.figure),
+            answer_notation=answer_notation_detail,
+        )
+        cot = self._chord_from_roman_cot(
+            rn,
+            notes,
+            tonic,
+            mode,
+            style,
+            answer_style,
+            force_answer_natural,
+            rendered_answer,
+        )
+        return self._problem(
+            "chord_from_roman_numeral",
+            prompt,
+            answer,
+            "note_sequence",
+            cot,
+            key=f"{tonic} {mode}",
+            roman_figure=AnswerNormalizer.roman(rn.figure),
+            chord_notes=[note.name(False) for note in notes],
+            answer_notation=answer_notation,
+            answer_explicit_accidentals=force_answer_natural,
+        )
+
+    def _chord_from_roman_cot(
+        self,
+        rn: m21_roman.RomanNumeral,
+        notes: Sequence[Note],
+        tonic: str,
+        mode: str,
+        prompt_style: str,
+        answer_style: str,
+        force_answer_natural: bool,
+        rendered_answer: str,
+    ) -> list[str]:
+        """Explain how a Roman numeral determines chord tones from bass upward."""
+        figure = AnswerNormalizer.roman(rn.figure)
+        root = Music21Adapter.note_from_pitch(rn.root()).without_octave()
+        bass = Music21Adapter.note_from_pitch(rn.bass()).without_octave()
+        root_position_notes = self._root_position_order(notes, root)
+        root_position_text = ChordRenderer.for_cot(root_position_notes, prompt_style, with_octave=False)
+        quality = rn.commonName
+        size = len(root_position_notes)
+        inversion = self._bass_member_index(root_position_notes, bass)
+        suffix = self._roman_suffix(size, inversion)
+        base = self._roman_base(figure, suffix)
+        member_name = ("root", "third", "fifth", "seventh")[inversion]
+        inversion_label = INVERSION_LABELS[size][inversion][0]
+        bass_upward_text = ChordRenderer.join(
+            [
+                NoteRenderer.note(
+                    note,
+                    answer_style,
+                    force_natural=force_answer_natural,
+                )
+                for note in notes
+            ]
+        )
+
+        return [
+            self._roman_to_root_sentence(base, root, quality, tonic, mode, prompt_style),
+            f"A {size}-note {quality} is built in stacked thirds as {root_position_text}.",
+            self._chord_from_roman_inversion_sentence(
+                figure,
+                suffix,
+                inversion_label,
+                member_name,
+                bass,
+                prompt_style,
+            ),
+            f"Writing the chord from bass upward gives {bass_upward_text}.",
+        ]
+
+    def _sample_chord(
+        self,
+        interval_table: dict[str, tuple[tuple[str, int], ...]],
+        with_octave: bool = False,
+        root_octave: int | None = None,
+        min_root_octave: int = 1,
+        max_root_octave: int = 6,
+    ) -> tuple[list[Note], str]:
+        """Sample a root-position chord that stays within accidental limits."""
+        qualities = tuple(interval_table)
+        max_accidental = self.config.max_accidental
+        if root_octave is not None:
+            with_octave = True
+            min_root_octave = root_octave
+            max_root_octave = root_octave
+        if min_root_octave > max_root_octave:
+            raise ValueError("Minimum root octave cannot exceed maximum root octave.")
+        for _ in range(GENERATION_RETRY_LIMIT):
+            root = Note.random(
+                self.config,
+                with_octave=with_octave,
+                octave_min=min_root_octave,
+                octave_max=max_root_octave,
+                accidental_limit=max_accidental,
+            )
+            quality = random.choice(qualities)
+            notes = [root] + [
+                Interval(interval_quality, number).construct_from(root)
+                for interval_quality, number in interval_table[quality]
+            ]
+            if all(abs(note.accidental) <= max_accidental for note in notes):
+                return notes, quality
+        raise ValueError("Could not construct a chord with supported accidentals.")
+
+    def _sample_chord_size(self) -> int:
+        """Sample whether a generated mode uses a triad or seventh chord."""
+        return 4 if random.random() < self.config.p_seventh else 3
+
+    def _sample_scale(self) -> tuple[Scale, str]:
+        """Sample a major or natural-minor scale context."""
+        key_complexity = self.config.key_complexity
+        if random.choice(["major", "minor"]) == "major":
+            tonic = Note.parse(random.choice(key_tonics("major", key_complexity)))
+            return Scale.build(tonic, "major"), "major"
+        tonic = Note.parse(random.choice(key_tonics("minor", key_complexity)))
+        return Scale.build(tonic, "natural_minor"), "natural minor"
+
+    def _sample_key_context(self) -> tuple[str, str, m21_key.Key]:
+        """Sample a music21 key context and its rendered label."""
+        key_complexity = self.config.key_complexity
+        if random.choice(["major", "minor"]) == "major":
+            tonic = random.choice(key_tonics("major", key_complexity))
+            return tonic, "major", m21_key.Key(tonic)
+        tonic = random.choice(key_tonics("minor", key_complexity))
+        return tonic, "minor", m21_key.Key(tonic, "minor")
+
+    def _scale_degree_formula(self, notes: Sequence[Note], tonic: str) -> str:
+        """Return a chromatic scale-degree formula relative to a tonic."""
+        tonic_note = Note.parse(tonic)
+        return "-".join(self._scale_degree_token(note, tonic_note) for note in notes)
+
+    def _scale_degree_token(self, note: Note, tonic: Note) -> str:
+        """Return one chromatic scale-degree token such as 'b6' or '#4'."""
+        degree = ((note.step - tonic.step) % 7) + 1
+        reference_pc = (tonic.pc + Interval.base_semitones_for(degree)) % 12
+        alteration = (note.pc - reference_pc + 6) % 12 - 6
+        if abs(alteration) > 2:
+            raise ValueError("Scale-degree alteration is outside supported accidental bounds.")
+        prefix = "b" *   -alteration if alteration < 0 else "#" * alteration
+        return f"{prefix}{degree}"
+
+    def _sample_chromatic_chord(
+        self,
+        with_octave: bool = False,
+    ) -> tuple[str, str, str, str, m21_roman.RomanNumeral, list[Note]]:
+        """Sample a chromatic chord label and key context within accidental bounds."""
+        max_accidental = self.config.max_accidental
+        key_complexity = self.config.key_complexity
+        for _ in range(GENERATION_RETRY_LIMIT):
+            label, figure = random.choice(CHROMATIC_CHORDS)
+            if random.choice(["major", "minor"]) == "major":
+                tonic = random.choice(key_tonics("major", key_complexity))
+                mode = "major"
+                key_context = m21_key.Key(tonic)
+            else:
+                tonic = random.choice(key_tonics("minor", key_complexity))
+                mode = "minor"
+                key_context = m21_key.Key(tonic, "minor")
+            rn = m21_roman.RomanNumeral(figure, key_context)
+            notes = [
+                Music21Adapter.note_from_pitch(pitch, with_octave=with_octave)
+                for pitch in rn.pitches
+            ]
+            if all(abs(note.accidental) <= max_accidental for note in notes):
+                return label, figure, tonic, mode, rn, notes
+        raise ValueError("Could not sample a chromatic chord within accidental bounds.")
+
+    def _sample_roman_context(
+        self,
+        with_octave: bool = False,
+    ) -> tuple[str, str, m21_roman.RomanNumeral, list[Note]]:
+        """Sample a Roman numeral, key, and chord spelling within current bounds."""
+        max_accidental = self.config.max_accidental
+        for _ in range(GENERATION_RETRY_LIMIT):
+            tonic, mode, key_context = self._sample_key_context()
+            rn = m21_roman.RomanNumeral(self._sample_roman_figure(mode), key_context)
+            notes = [
+                Music21Adapter.note_from_pitch(pitch, with_octave=with_octave)
+                for pitch in rn.pitches
+            ]
+            if all(abs(note.accidental) <= max_accidental for note in notes):
+                return tonic, mode, rn, notes
+        raise ValueError("Could not sample a Roman numeral within accidental bounds.")
+
+    def _sample_roman_figure(self, mode: str) -> str:
+        """Sample a Roman numeral whose size determines the possible inversions."""
+        if self._sample_chord_size() == 4:
+            diatonic_pool = ROMAN_MAJOR_SEVENTHS if mode == "major" else ROMAN_MINOR_SEVENTHS
+            suffix = random.choice(SEVENTH_INVERSION_SUFFIXES)
+            figure = self._with_roman_inversion(random.choice(diatonic_pool), suffix)
+            secondary_pool = (
+                ROMAN_MAJOR_SECONDARY_SEVENTHS
+                if mode == "major"
+                else ROMAN_MINOR_SECONDARY_SEVENTHS
+            )
+        else:
+            diatonic_pool = ROMAN_MAJOR_TRIADS if mode == "major" else ROMAN_MINOR_TRIADS
+            suffix = random.choice(TRIAD_INVERSION_SUFFIXES)
+            figure = self._with_roman_inversion(random.choice(diatonic_pool), suffix)
+            secondary_pool = (
+                ROMAN_MAJOR_SECONDARY_TRIADS
+                if mode == "major"
+                else ROMAN_MINOR_SECONDARY_TRIADS
+            )
+        if random.random() < self.config.p_secondary:
+            figure = self._with_roman_inversion(random.choice(secondary_pool), suffix)
+        return figure
+
+    @staticmethod
+    def _root_position_order(notes: Sequence[Note], root: Note) -> list[Note]:
+        """Order chord tones from root upward by stacked thirds, ignoring octave."""
+        return sorted(
+            [note.without_octave() for note in notes],
+            key=lambda note: (note.step - root.step) % 7,
+        )
+
+    @staticmethod
+    def _render_cot_note(note: Note, style: str) -> str:
+        """Render one note for a CoT in the prompt's notation family."""
+        note_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        return NoteRenderer.note(
+            note.without_octave(),
+            note_style,
+            force_natural=style == FULL_ABC_SCORE_STYLE,
+        )
+
+    def _roman_interval_phrases(self, root_position_notes: Sequence[Note], style: str) -> str:
+        """Describe intervals from the root to the other stacked chord tones."""
+        root = root_position_notes[0]
+        phrases = []
+        for note in root_position_notes[1:]:
+            interval = Interval.between(root, note, without_octaves=True)
+            phrases.append(
+                f"from {self._render_cot_note(root, style)} to {self._render_cot_note(note, style)}, "
+                f"{TextFormatter.article(interval.name())}"
+            )
+        return "; ".join(phrases)
+
+    @staticmethod
+    def _bass_member_index(root_position_notes: Sequence[Note], bass: Note) -> int:
+        """Return which root-position chord member is in the bass."""
+        bass_without_octave = bass.without_octave()
+        for index, note in enumerate(root_position_notes):
+            if note.same_spelling(bass_without_octave):
+                return index
+        raise ValueError("Bass note is not one of the chord tones.")
+
+    @staticmethod
+    def _roman_suffix(size: int, inversion: int) -> str:
+        """Return the compact figured-bass suffix for a chord size and inversion."""
+        if size == 3:
+            return TRIAD_INVERSION_SUFFIXES[inversion]
+        if size == 4:
+            return SEVENTH_INVERSION_SUFFIXES[inversion]
+        raise ValueError(f"Unsupported chord size for Roman suffix: {size}")
+
+    @staticmethod
+    def _roman_base(figure: str, suffix: str) -> str:
+        """Remove the inversion suffix from a compact Roman numeral."""
+        if not suffix:
+            return figure
+        if "/o" in figure:
+            return figure[: -len(suffix)]
+        chord_part, slash, target = figure.partition("/")
+        if slash:
+            chord_part = chord_part[: -len(suffix)]
+            return f"{chord_part}{slash}{target}"
+        return figure[: -len(suffix)]
+
+    @staticmethod
+    def _roman_suffix_phrase(suffix: str, size: int) -> str:
+        """Return readable wording for the Roman figured-bass suffix."""
+        if suffix:
+            return f"the Roman suffix is {suffix}"
+        if size == 3:
+            return "there is no triad suffix"
+        return "there is no suffix"
+
+    @staticmethod
+    def _roman_suffix_combination_phrase(suffix: str) -> str:
+        """Return suffix wording for the final Roman-numeral combination."""
+        return f"suffix {suffix}" if suffix else "no suffix"
+
+    @staticmethod
+    def _roman_combination_sentence(base: str, suffix: str, answer: str) -> str:
+        """Explain how the Roman base and inversion suffix form the answer."""
+        if "/" in base and "/o" not in base and suffix:
+            return f"Inserting suffix {suffix} before the slash in {base} gives {answer}."
+        return f"Combining the base {base} with {ChordRomanReasoning._roman_suffix_combination_phrase(suffix)} gives {answer}."
+
+    @staticmethod
+    def _secondary_target(base: str) -> str | None:
+        """Return the secondary target after the slash, excluding half-diminished /o."""
+        if "/o" in base:
+            return None
+        _local_base, slash, target = base.partition("/")
+        return target if slash else None
+
+    def _roman_function_sentence(
+        self,
+        base: str,
+        root: Note,
+        quality: str,
+        tonic: str,
+        mode: str,
+        style: str,
+    ) -> str:
+        """Explain why the root and quality imply the Roman base."""
+        target = self._secondary_target(base)
+        if target is not None:
+            local_base = base.partition("/")[0]
+            return (
+                f"In {tonic} {mode}, {TextFormatter.article(quality)} on "
+                f"{self._render_cot_note(root, style)} functions as local {local_base} "
+                f"that resolves to {target}. Applied function is written with a slash, "
+                f"so the Roman base is {base}."
+            )
+
+        degree = ((root.step - Note.parse(tonic).step) % 7) + 1
+        return (
+            f"In {tonic} {mode}, root {self._render_cot_note(root, style)} is scale degree {degree}; "
+            f"with this quality, the Roman base is {base}."
+        )
+
+    def _roman_to_root_sentence(
+        self,
+        base: str,
+        root: Note,
+        quality: str,
+        tonic: str,
+        mode: str,
+        style: str,
+    ) -> str:
+        """Explain how the Roman base selects a root and chord quality."""
+        root_text = self._render_cot_note(root, style)
+        target = self._secondary_target(base)
+        if target is not None:
+            local_base = base.partition("/")[0]
+            return (
+                f"The Roman base {base} means local {local_base} applied to {target} in {tonic} {mode}. "
+                f"That gives {TextFormatter.article(quality)} on root {root_text}."
+            )
+
+        degree = ((root.step - Note.parse(tonic).step) % 7) + 1
+        return (
+            f"In {tonic} {mode}, Roman base {base} uses scale degree {degree}, "
+            f"so the root is {root_text} and the chord quality is {TextFormatter.article(quality)}."
+        )
+
+    def _chord_from_roman_inversion_sentence(
+        self,
+        figure: str,
+        suffix: str,
+        inversion_label: str,
+        member_name: str,
+        bass: Note,
+        style: str,
+    ) -> str:
+        """Explain how the figured-bass suffix chooses the bass note."""
+        bass_text = self._render_cot_note(bass, style)
+        if suffix:
+            return (
+                f"The suffix {suffix} in {figure} means {inversion_label}; "
+                f"therefore, the chordal {member_name}, {bass_text}, is in the bass."
+            )
+        return (
+            f"Because {figure} has no inversion suffix, it is in root position; "
+            f"therefore, the chordal root, {bass_text}, is in the bass."
+        )
+
+    @staticmethod
+    def _with_roman_inversion(figure: str, suffix: str) -> str:
+        """Attach figured-bass suffix before any secondary-function slash."""
+        if not suffix:
+            return figure
+        if "/o" in figure:
+            return f"{figure[:-1] if figure.endswith('7') else figure}{suffix}"
+        chord_part, slash, target = figure.partition("/")
+        if chord_part.endswith("7"):
+            chord_part = chord_part[:-1]
+        return f"{chord_part}{suffix}{slash}{target}"
+
+    def _sample_diatonic_chord(self, scale: Scale, size: int) -> list[Note]:
+        """Sample a tertian chord from one scale collection."""
+        degree_index = random.randrange(7)
+        offsets = (0, 2, 4, 6)[:size]
+        return [scale.degrees[(degree_index + offset) % 7] for offset in offsets]

--- a/reasoning_core/tasks/pitch_interval_reasoning.py
+++ b/reasoning_core/tasks/pitch_interval_reasoning.py
@@ -1,0 +1,1129 @@
+from dataclasses import dataclass
+from collections.abc import Sequence
+import random
+from typing import Any
+
+from reasoning_core.template import Config, Problem, Task, edict
+from reasoning_core.tasks._music_theory import (
+    ABCContext,
+    AnswerNormalizer,
+    CHOICE_TAILS,
+    COMPACT_ABC_STYLE,
+    FULL_ABC_SCORE_SHARE,
+    FULL_ABC_SCORE_STYLE,
+    GENERATION_RETRY_LIMIT,
+    INTEGER_TAILS,
+    INTERVAL_CLASS_LABELS,
+    MINOR_SCALE_MODES,
+    Note,
+    NoteRenderer,
+    NOTE_ANSWER_TAILS,
+    PITCH_CLASS_LABELS,
+    PromptFormatter,
+    Scale,
+    SPN_STYLE,
+    TextFormatter,
+    Interval,
+    YES_NO_TAILS,
+    key_tonics,
+)
+
+MODE_NAMES = (
+    "interval_naming",
+    "interval_arithmetic",
+    "pitch_count",
+    "interval_classification",
+    "enharmonic_interval_comparison",
+    "instrument_transposition",
+    "interval_construction",
+    "transposition_chain",
+)
+
+INTERVAL_CONSTRUCTION_CASES = (
+    "prompt_octave_answer_octave",
+    "prompt_octave_answer_no_octave",
+    "prompt_no_octave_answer_no_octave",
+)
+# Common written-to-sounding transpositions used here; every instrument sounds
+# the listed interval lower than written.
+TRANSPOSING_INSTRUMENTS = (
+    ("B-flat clarinet", "major", 2),
+    ("B-flat trumpet", "major", 2),
+    ("A clarinet", "minor", 3),
+    ("F horn", "perfect", 5),
+    ("English horn", "perfect", 5),
+    ("B-flat soprano saxophone", "major", 2),
+    ("E-flat alto saxophone", "major", 6),
+    ("B-flat tenor saxophone", "major", 9),
+    ("E-flat baritone saxophone", "major", 13),
+    ("B-flat bass clarinet", "major", 9),
+    ("guitar", "perfect", 8),
+    ("double bass", "perfect", 8),
+)
+
+INTERVAL_NAME_OPENERS = (
+    "Name the interval from {start} to {end}.",
+    "Identify the interval from {start} up to {end}.",
+    "What interval goes from {start} to {end}?",
+    "Classify the interval formed by {start} and {end}.",
+    "Determine the interval from {start} to {end}.",
+    "Give the interval from {start} up to {end}.",
+    "What is the written interval between {start} and {end}?",
+    "Name the ascending interval whose endpoints are {start} and {end}.",
+)
+INTERVAL_NAME_SCORE_OPENERS = (
+    "Name the interval between the two notes in this ABC score fragment:\n{score}",
+    "Identify the interval shown by the two notes in this ABC score fragment:\n{score}",
+    "What interval is formed by the two notes in this ABC score fragment?\n{score}",
+    "Classify the interval in this ABC score fragment:\n{score}",
+    "Determine the interval represented by the two notes in this ABC score fragment:\n{score}",
+    "Name the harmonic interval shown in this ABC score fragment:\n{score}",
+    "What written interval do the two notes in this ABC score fragment form?\n{score}",
+    "Identify the interval between the two notated pitches in this ABC score fragment:\n{score}",
+)
+INTERVAL_NAME_TAILS = (
+    "The answer is one interval name, including compound/simple size as written.",
+    "Give one interval name, keeping the compound or simple size as written.",
+    "Answer with one interval name, preserving whether the interval is simple or compound.",
+    "The expected answer is one interval name with the written interval size preserved.",
+    "Provide one interval name, using the compound or simple size shown.",
+)
+INTERVAL_ARITHMETIC_SINGLE_OPENERS = {
+    "add": (
+        "Add {operand} to {start_interval}.",
+        "Combine {start_interval} with {operand} by addition.",
+        "Starting from {start_interval}, add {operand}.",
+        "Use interval addition to combine {start_interval} and {operand}.",
+        "Find the interval produced by adding {operand} to {start_interval}.",
+    ),
+    "subtract": (
+        "Subtract {operand} from {start_interval}.",
+        "Starting from {start_interval}, subtract {operand}.",
+        "Remove {operand} from {start_interval} by interval arithmetic.",
+        "Use interval subtraction to take {operand} away from {start_interval}.",
+        "Find the interval left after subtracting {operand} from {start_interval}.",
+    ),
+    "reduce_then_invert": (
+        "Reduce {start_interval} to a simple interval and invert it.",
+        "Starting from {start_interval}, reduce it to a simple interval, then invert it.",
+        "Take {start_interval}, reduce it to simple form, and invert the result.",
+        "Convert {start_interval} to its simple form, then invert that simple interval.",
+        "Find the inversion after reducing {start_interval} to a simple interval.",
+    ),
+}
+INTERVAL_ARITHMETIC_CHAIN_OPENERS = (
+    "Start with {start_interval}, then {operations}.",
+    "Beginning with {start_interval}, perform these steps: {operations}.",
+    "Apply this interval-arithmetic chain to {start_interval}: {operations}.",
+    "From {start_interval}, carry out this sequence of interval operations: {operations}.",
+    "Use {start_interval} as the starting interval, then {operations}.",
+    "Compute the result of this interval chain starting at {start_interval}: {operations}.",
+)
+INTERVAL_ONLY_TAILS = (
+    "The answer is one interval name.",
+    "Give one interval name.",
+    "Answer with one interval name.",
+    "Provide a single interval name.",
+    "The expected answer is one interval name.",
+)
+PITCH_COUNT_OPENERS = (
+    "Under pitch-class equivalence, how many distinct pitch classes are in {notes}?",
+    "How many distinct pitch classes appear in {notes}?",
+    "Counting enharmonically equivalent spellings as the same pitch class, how many distinct pitch classes are in {notes}?",
+    "Reduce {notes} to pitch classes. How many distinct pitch classes are present?",
+    "Treat octave and enharmonic spelling differences as pitch-class equivalence. How many distinct pitch classes are in {notes}?",
+    "How many different pitch classes are represented by {notes}?",
+    "After reducing {notes} to pitch classes, how many unique classes remain?",
+    "Count the distinct pitch classes represented in {notes}.",
+)
+PITCH_COUNT_SCORE_OPENERS = (
+    "Under pitch-class equivalence, how many distinct pitch classes are in this ABC score fragment?\n{score}",
+    "How many distinct pitch classes appear in this ABC score fragment?\n{score}",
+    "Counting enharmonically equivalent spellings as the same pitch class, how many distinct pitch classes are in this ABC score fragment?\n{score}",
+    "Reduce the notes in this ABC score fragment to pitch classes. How many distinct pitch classes are present?\n{score}",
+    "How many different pitch classes are represented in this ABC score fragment?\n{score}",
+    "Count the distinct pitch classes in this ABC score fragment:\n{score}",
+)
+INTERVAL_CLASSIFICATION_OPENERS = (
+    "In {key}, classify the note-to-note relation {relation}.",
+    "For {key}, label the relation {relation}.",
+    "Using {key}, classify the note-to-note relation {relation}.",
+    "In the collection {key}, what label applies to the relation {relation}?",
+    "Within {key}, choose the label for the relation {relation}.",
+    "Using the {key} collection, classify the relation {relation}.",
+    "For the key context {key}, what label fits the relation {relation}?",
+    "Determine whether the relation {relation} in {key} is diatonic consonance, diatonic dissonance, or chromatic alteration.",
+)
+ENHARMONIC_INTERVAL_OPENERS = (
+    "Are {first} and {second} enharmonically equivalent intervals?",
+    "Do {first} and {second} represent enharmonically equivalent intervals?",
+    "Compare {first} and {second}: are the intervals enharmonically equivalent?",
+    "Do the corresponding endpoint pitches of {first} and {second} match enharmonically?",
+    "Check whether {first} and {second} are enharmonically equivalent written intervals.",
+    "Do {first} and {second} describe intervals with matching sounding endpoints?",
+    "Are the two written intervals {first} and {second} enharmonically the same?",
+    "Compare the endpoint pitches of {first} and {second}. Are the intervals enharmonically equivalent?",
+)
+ENHARMONIC_INTERVAL_SCORE_OPENERS = (
+    "Is the interval in this ABC score fragment:\n{first}\nenharmonically equivalent to the interval in this ABC score fragment:\n{second}?",
+    "Compare the interval in this ABC score fragment:\n{first}\nwith the interval in this ABC score fragment:\n{second}\nAre they enharmonically equivalent?",
+    "Do these two ABC score fragments show enharmonically equivalent intervals?\nFirst fragment:\n{first}\nSecond fragment:\n{second}",
+    "After interpreting the key signatures, are the intervals in these ABC score fragments enharmonically equivalent?\nFirst fragment:\n{first}\nSecond fragment:\n{second}",
+    "Compare the two notated intervals below for enharmonic equivalence.\nFirst fragment:\n{first}\nSecond fragment:\n{second}",
+    "Do the corresponding endpoint pitches match in these two ABC interval fragments?\nFirst fragment:\n{first}\nSecond fragment:\n{second}",
+)
+ABC_PAIR_YES_NO_TAILS = (
+    "Interpret each ABC score using its key signature. The answer is exactly 'yes' or 'no'.",
+    "Use each ABC score's key signature, then answer exactly 'yes' or 'no'.",
+    "After resolving both ABC scores by key signature, give one answer: 'yes' or 'no'.",
+    "Resolve both ABC scores using their key signatures, then respond with exactly 'yes' or 'no'.",
+)
+INSTRUMENT_TRANSPOSITION_OPENERS = (
+    "{instrument_article} part writes {written}. What sounding pitch is produced?",
+    "{instrument_article} part has written note {written}. What is the sounding pitch?",
+    "For {instrument_article_lower} part, convert the written note {written} to sounding pitch.",
+    "{instrument_article} part writes {written}; convert it to sounding pitch.",
+    "{instrument_article} part has written pitch {written}. What pitch actually sounds?",
+    "{instrument_article} part notates {written}. What pitch actually sounds?",
+)
+INSTRUMENT_TRANSPOSITION_SCORE_OPENERS = (
+    "{instrument_article} part writes the note in this ABC score fragment:\n{score}\nWhat sounding pitch is produced?",
+    "For {instrument_article_lower} part, convert the written note in this ABC score fragment to sounding pitch:\n{score}",
+    "{instrument_article} part uses this written ABC score fragment:\n{score}\nWhat pitch sounds?",
+    "{instrument_article} part uses this written ABC score fragment. What sounding pitch results?\n{score}",
+    "{instrument_article} part writes the note in the ABC score fragment below. Convert it to sounding pitch:\n{score}",
+    "{instrument_article} part notates the pitch in this ABC score fragment:\n{score}\nWhat pitch actually sounds?",
+)
+INTERVAL_CONSTRUCTION_OPENERS = (
+    "Build {interval} {position} {start}.",
+    "Find the note {interval} {position} {start}.",
+    "Starting from {start}, build {interval} {position}.",
+    "What note lies {interval} {position} {start}?",
+    "Construct the note {interval} {position} {start}.",
+    "From {start}, move {interval} {position}.",
+)
+INTERVAL_CONSTRUCTION_SCORE_OPENERS = (
+    "Build {interval} {position} the note in this ABC score fragment:\n{score}",
+    "Find the note {interval} {position} the note in this ABC score fragment:\n{score}",
+    "Starting from the note in this ABC score fragment, build {interval} {position}:\n{score}",
+    "Construct the note {interval} {position} the note shown in this ABC score fragment:\n{score}",
+    "What note lies {interval} {position} the note in this ABC score fragment?\n{score}",
+    "Use the note in this ABC score fragment as the starting note, then build {interval} {position}:\n{score}",
+)
+TRANSPOSITION_CHAIN_OPENERS = (
+    "Transpose {start} {steps}.",
+    "Starting from {start}, apply these transpositions in order: {steps}.",
+    "Move from {start} through this transposition chain: {steps}.",
+    "Begin on {start} and perform these transpositions in order: {steps}.",
+    "Apply the ordered transposition sequence {steps} starting from {start}.",
+    "From {start}, transpose step by step: {steps}.",
+)
+TRANSPOSITION_CHAIN_SCORE_OPENERS = (
+    "Transpose the note in this ABC score fragment:\n{score}\nApply these transpositions in order: {steps}.",
+    "Starting from the note in this ABC score fragment, apply these transpositions in order:\n{score}\n{steps}.",
+    "Use the note in this ABC score fragment as the start, then transpose {steps}:\n{score}",
+    "Begin with the note in this ABC score fragment and perform these transpositions in order:\n{score}\n{steps}.",
+    "Apply this ordered transposition chain to the note in the ABC score fragment:\n{score}\n{steps}.",
+    "Take the note in this ABC score fragment as the starting pitch, then transpose {steps}:\n{score}",
+)
+
+@dataclass
+class PitchIntervalConfig(Config):
+    """Configuration knobs for pitch- and interval-reasoning generation."""
+
+    # Which generation mode to use. "any" samples uniformly among all supported modes.
+    mode: str = "any"
+
+    # Shared length knob for chain-like tasks, such as interval arithmetic
+    # operation chains and sequential transpositions.
+    chain_len: int = 1
+
+    # Largest diatonic interval number allowed. 8 is an octave, 9 is a ninth,
+    # 10 is a tenth, and so on; larger values make compound intervals possible.
+    max_interval_number: int = 8
+
+    # Number of note items in count-style tasks. Higher values produce longer
+    # note lists with more duplicates and enharmonic distractors.
+    n_candidates: int = 4
+
+    # Maximum accidental complexity in generated spellings: 0 allows naturals,
+    # 1 allows sharps/flats, and 2 allows double-sharps/double-flats.
+    max_accidental: int = 1
+
+    # Maximum number of sharps/flats in analytical key signatures.
+    key_complexity: int = 2
+
+    # Probability of writing prompt notes in ABC notation instead of scientific
+    # pitch notation. ABC examples are split into 70% compact note tokens and
+    # 30% full score fragments with randomly sampled common L/M/K headers.
+    p_abc: float = 0.20
+
+    # Maximum attempts to generate a valid instance before failing. Some random
+    # combinations are rejected because they require unsupported spellings.
+    max_tries: int = 256
+
+    # Override of Config.update; called by Config.set_level() to raise difficulty.
+    def update(self, c: float = 1) -> None:
+        """Increase generation difficulty by updating monotonic config knobs."""
+        self.chain_len += 0.6 * c
+        self.max_interval_number = min(20, self.max_interval_number + 1.5 * c)
+        self.n_candidates += c
+        self.max_accidental = min(2, self.max_accidental + 0.2 * c)
+        self.key_complexity = min(7, self.key_complexity + c)
+        self.p_abc = min(0.50, self.p_abc + 0.06 * c)
+
+    def random_style(self) -> str:
+        """Sample the note-rendering style for a prompt."""
+        roll = random.random()
+        if roll < FULL_ABC_SCORE_SHARE * self.p_abc:
+            return FULL_ABC_SCORE_STYLE
+        if roll < self.p_abc:
+            return COMPACT_ABC_STYLE
+        return SPN_STYLE
+
+
+class PitchIntervalReasoning(Task):
+    """Procedural generator for pitch, interval, key, and transposition tasks."""
+
+    # Override of Task.__init__; keeps the normal task setup and adjusts balancing.
+    def __init__(self, config: PitchIntervalConfig = PitchIntervalConfig()) -> None:
+        """Initialize the task and tighten batch balancing for low-cardinality modes."""
+        super().__init__(config=config)
+        # The default 0.5 allows too many repeats for low-cardinality modes
+        # such as yes/no comparison and three-label interval classification.
+        self.balancing_key_ratio = 0.3
+
+    def _sample_mode(self) -> str:
+        """Choose a concrete generation mode from the configured mode setting."""
+        if self.config.mode != "any":
+            if self.config.mode not in MODE_NAMES:
+                raise ValueError(f"Unknown pitch interval mode: {self.config.mode}")
+            return self.config.mode
+        return random.choice(MODE_NAMES)
+
+    # Override of Task.generate; returns one generated Problem.
+    def generate(self) -> Problem:
+        """Generate one pitch/interval reasoning problem."""
+        mode = self._sample_mode()
+        for _ in range(self.config.max_tries):
+            try:
+                # Dispatch by convention: "pitch_count" -> self._generate_pitch_count().
+                return getattr(self, f"_generate_{mode}")()
+            except (KeyError, ValueError):
+                continue
+        raise RuntimeError(f"Failed to generate a pitch_interval_reasoning instance for mode {mode!r}.")
+
+    # Override of Task.prompt; prompt text is already stored in metadata.
+    def prompt(self, metadata: Any) -> str:
+        """Return the prompt string stored in generated metadata."""
+        return metadata.prompt
+
+    # Override of Task.score_answer; normalizes music-specific answer formats.
+    def score_answer(self, answer: object, entry: Problem) -> float:
+        """Score an answer after normalizing the expected music-answer format."""
+        expected = str(entry.answer)
+        # Older metadata may omit answer_kind, so plain text remains the fallback.
+        kind = entry.metadata.get("answer_kind", "text")
+        if kind == "note":
+            answer_notation = entry.metadata.get("answer_notation")
+            return float(AnswerNormalizer.note(answer, answer_notation) == AnswerNormalizer.note(expected, answer_notation))
+        if kind == "interval":
+            return float(AnswerNormalizer.interval(answer) == AnswerNormalizer.interval(expected))
+        if kind == "yes_no":
+            return float(AnswerNormalizer.text(answer) == expected)
+        if kind == "integer":
+            try:
+                return float(int(answer) == int(expected))
+            except Exception:
+                return 0.0
+        return float(AnswerNormalizer.text(answer) == AnswerNormalizer.text(expected))
+
+    # Override of Task.balancing_key; limits repeats of the same mode-answer pair.
+    def balancing_key(self, problem: Problem) -> str:
+        """Return the batch-balancing key for this generated problem."""
+        return f"{problem.metadata.mode}:{problem.answer}"
+
+    def _problem(
+        self,
+        mode: str,
+        prompt: str,
+        answer: object,
+        answer_kind: str,
+        cot: Sequence[str],
+        **metadata: Any,
+    ) -> Problem:
+        """Package prompt, answer, reasoning trace, and metadata as a Problem."""
+        meta = edict(mode=mode, prompt=prompt, answer_kind=answer_kind, cot="\n".join(cot), **metadata)
+        return Problem(metadata=meta, answer=str(answer))
+
+    def _generate_interval_naming(self) -> Problem:
+        """Generate a task asking for the named interval between two notes."""
+        style = self.config.random_style()
+        start, end, quality, number = self._sample_constructed_pair()
+        interval = Interval(quality, number, start, end)
+        answer = interval.name()
+        note_token_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        rendered_start = NoteRenderer.note(start, note_token_style, force_natural=style == FULL_ABC_SCORE_STYLE)
+        rendered_end = NoteRenderer.note(end, note_token_style, force_natural=style == FULL_ABC_SCORE_STYLE)
+        resolution_cot = []
+        if style == FULL_ABC_SCORE_STYLE:
+            rendered_pair, rendered_notes, abc_context = ABCContext.interval_score_with_resolution(start, end)
+            resolution_cot = [abc_context.resolution_sentence(note) for note in rendered_notes]
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_NAME_SCORE_OPENERS,
+                INTERVAL_NAME_TAILS,
+                style=style,
+                notation_separator="\n",
+                score=rendered_pair,
+            )
+        else:
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_NAME_OPENERS,
+                INTERVAL_NAME_TAILS,
+                style=style,
+                start=rendered_start,
+                end=rendered_end,
+            )
+        cot = resolution_cot + [
+            f"Counting the note letters from the first note up to the second note, including octave changes, gives interval number {interval.number} ({interval.number_name}).",
+            f"The chromatic distance from {rendered_start} to {rendered_end} is {TextFormatter.count_phrase(interval.chromatic_distance)}.",
+            f"The major/perfect form of {TextFormatter.article(interval.number_name)} is {TextFormatter.count_phrase(interval.base_semitones)}.",
+            f"Comparing those distances gives the quality {interval.quality}.",
+            f"So the interval is {TextFormatter.article(answer)}.",
+        ]
+        return self._problem(
+            "interval_naming",
+            prompt,
+            answer,
+            "interval",
+            cot,
+            start_note=start.name(),
+            end_note=end.name(),
+            style=style,
+        )
+
+    def _generate_interval_arithmetic(self) -> Problem:
+        """Generate a task combining named intervals by arithmetic operations."""
+        start_interval, steps = self._sample_interval_arithmetic_chain()
+        answer_interval = steps[-1][2]
+        answer = answer_interval.name()
+        start_interval_text = TextFormatter.article(start_interval.name())
+        if len(steps) == 1:
+            operation, operand, _ = steps[0]
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_ARITHMETIC_SINGLE_OPENERS[operation],
+                INTERVAL_ONLY_TAILS,
+                start_interval=start_interval_text,
+                operand=TextFormatter.article(operand.name()) if operand is not None else "",
+            )
+        else:
+            operations = ", then ".join(
+                self._interval_arithmetic_operation_phrase(operation, interval)
+                for operation, interval, _ in steps
+            )
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_ARITHMETIC_CHAIN_OPENERS,
+                INTERVAL_ONLY_TAILS,
+                start_interval=start_interval_text,
+                operations=operations,
+            )
+
+        operation_names = [operation for operation, _, _ in steps]
+        cot = [
+            f"Start with {TextFormatter.article(start_interval.name())}: interval number {start_interval.number} and {TextFormatter.count_phrase(start_interval.semitones)}.",
+        ]
+        if any(operation in {"add", "subtract"} for operation in operation_names):
+            cot.append("For interval numbers, addition uses current + interval - 1, and subtraction uses current - interval + 1.")
+        if "reduce_then_invert" in operation_names:
+            cot.append(
+                "For reduce-then-invert, first reduce compound interval numbers by subtracting 7 for each octave; "
+                "then invert the simple interval so the two simple interval numbers add to 9."
+            )
+        current = start_interval
+        for operation, operand, result in steps:
+            if operation == "add":
+                cot.append(
+                    f"Add {TextFormatter.article(operand.name())}: interval number {current.number} + {operand.number} - 1 = {result.number}, "
+                    f"and semitones {current.semitones} + {operand.semitones} = {result.semitones}."
+                )
+            elif operation == "subtract":
+                cot.append(
+                    f"Subtract {TextFormatter.article(operand.name())}: interval number {current.number} - {operand.number} + 1 = {result.number}, "
+                    f"and semitones {current.semitones} - {operand.semitones} = {result.semitones}."
+                )
+            else:
+                reduced = current.reduced()
+                cot.append(
+                    f"Reduce {TextFormatter.article(current.name())} to {TextFormatter.article(reduced.name())}; "
+                    f"then invert it: 9 - {reduced.number} = {result.number}, and {reduced.quality} inverts to {result.quality}."
+                )
+            current = result
+        cot.append(
+            f"With interval number {answer_interval.number} and {TextFormatter.count_phrase(answer_interval.semitones)}, "
+            f"the resulting interval is {TextFormatter.article(answer)}."
+        )
+        return self._problem(
+            "interval_arithmetic",
+            prompt,
+            answer,
+            "interval",
+            cot,
+            start_interval_quality=start_interval.quality,
+            start_interval_number=start_interval.number,
+            operations=[
+                self._interval_arithmetic_metadata(operation, operand)
+                for operation, operand, _ in steps
+            ],
+        )
+
+    def _interval_arithmetic_operation_phrase(self, operation: str, operand: Interval | None) -> str:
+        """Render one interval-arithmetic operation in a prompt."""
+        if operation in {"add", "subtract"}:
+            return f"{operation} {TextFormatter.article(operand.name())}"
+        if operation == "reduce_then_invert":
+            return "reduce to a simple interval and invert it"
+        raise ValueError(f"Unsupported interval-arithmetic operation: {operation}")
+
+    def _interval_arithmetic_metadata(self, operation: str, operand: Interval | None) -> dict[str, object]:
+        """Render compact operation metadata for one interval-arithmetic step."""
+        metadata: dict[str, object] = {"operation": operation}
+        if operand is not None:
+            metadata["interval_quality"] = operand.quality
+            metadata["interval_number"] = operand.number
+        return metadata
+
+    def _generate_pitch_count(self) -> Problem:
+        """Generate a task counting distinct pitch classes in a note list."""
+        style = self.config.random_style()
+        accidental_limit = self.config.max_accidental
+        n_candidates = self.config.n_candidates
+        distinct = random.randint(2, n_candidates)
+        pcs = random.sample(range(12), distinct)
+        notes = []
+        for pc in pcs:
+            notes.append(random.choice(Note.spellings_for_pitch_class(pc, accidental_limit, with_octave=True)))
+        while len(notes) < n_candidates:
+            pc = random.choice(pcs)
+            notes.append(random.choice(Note.spellings_for_pitch_class(pc, accidental_limit, with_octave=True)))
+        random.shuffle(notes)
+        rendered_note_list, rendered_notes, resolution_cot = NoteRenderer.sequence(notes, style)
+        if style == FULL_ABC_SCORE_STYLE:
+            prompt = PromptFormatter.choice_prompt(
+                PITCH_COUNT_SCORE_OPENERS,
+                INTEGER_TAILS,
+                style=style,
+                notation_separator="\n",
+                score=rendered_note_list,
+            )
+        else:
+            prompt = PromptFormatter.choice_prompt(
+                PITCH_COUNT_OPENERS,
+                INTEGER_TAILS,
+                style=style,
+                notes=rendered_note_list,
+            )
+        unique_pcs = sorted({note.pc for note in notes})
+        cot = resolution_cot + [
+            f"{rendered_note} maps to pitch class {note.pc} ({PITCH_CLASS_LABELS[note.pc]})."
+            for rendered_note, note in zip(rendered_notes, notes)
+        ]
+        cot.append(
+            "The distinct pitch classes are "
+            + ", ".join(f"{pc} ({PITCH_CLASS_LABELS[pc]})" for pc in unique_pcs)
+            + f", so there are {TextFormatter.count_phrase(len(unique_pcs), 'distinct pitch class', 'distinct pitch classes')}."
+        )
+        return self._problem(
+            "pitch_count",
+            prompt,
+            len(unique_pcs),
+            "integer",
+            cot,
+            notes=[n.name() for n in notes],
+            style=style,
+        )
+
+    def _generate_interval_classification(self) -> Problem:
+        """Generate a task classifying a note-to-note relation in a key."""
+        accidental_limit = self.config.max_accidental
+        key_complexity = self.config.key_complexity
+        if random.choice(["major", "minor"]) == "major":
+            scale_mode = "major"
+            key_label = "major"
+            tonic = Note.parse(random.choice(key_tonics("major", key_complexity)))
+        else:
+            scale_mode, key_label = random.choice(MINOR_SCALE_MODES)
+            tonic = Note.parse(random.choice(key_tonics("minor", key_complexity)))
+        scale = Scale.build(tonic, scale_mode)
+
+        label = random.choice(INTERVAL_CLASS_LABELS)
+        if label == "chromatic alteration":
+            first = Note.random(self.config, with_octave=False, accidental_limit=accidental_limit)
+            if scale.contains(first):
+                second = random.choice(scale.chromatic_alterations())
+            else:
+                second = Note.random(self.config, with_octave=False, accidental_limit=accidental_limit)
+        else:
+            candidates = [
+                (first, second)
+                for first in scale.degrees
+                for second in scale.degrees
+                if not first.same_spelling(second)
+                and scale.relation_label(first, second) == label
+            ]
+            first, second = random.choice(candidates)
+
+        first_in_key = scale.contains(first)
+        second_in_key = scale.contains(second)
+        prompt = PromptFormatter.choice_prompt(
+            INTERVAL_CLASSIFICATION_OPENERS,
+            CHOICE_TAILS,
+            key=f"{tonic.name(False)} {key_label}",
+            relation=f"{first.name(False)}-{second.name(False)}",
+            options=PromptFormatter.options(INTERVAL_CLASS_LABELS),
+        )
+        scale_text = ", ".join(note.name(False) for note in scale.degrees)
+        cot = [f"The {tonic.name(False)} {key_label} collection is {scale_text}."]
+        cot.append(
+            f"{first.name(False)} is {'in' if first_in_key else 'not in'} the collection, "
+            f"and {second.name(False)} is {'in' if second_in_key else 'not in'} the collection."
+        )
+        if label == "chromatic alteration":
+            cot.append("At least one note is outside the collection, so the relation is a chromatic alteration.")
+        else:
+            interval = Interval.between(first, second, without_octaves=True)
+            consonance_word = "consonance" if label == "diatonic consonance" else "dissonance"
+            cot.append(
+                f"The written interval from {first.name(False)} to {second.name(False)} "
+                f"is {TextFormatter.article(interval.name())}."
+            )
+            cot.append(f"Since both notes are diatonic and the interval is a {consonance_word}, the label is {label}.")
+        return self._problem(
+            "interval_classification",
+            prompt,
+            label,
+            "label",
+            cot,
+            tonic_note=tonic.name(False),
+            scale_mode=scale_mode,
+            start_note=first.name(False),
+            end_note=second.name(False),
+        )
+
+    def _generate_enharmonic_interval_comparison(self) -> Problem:
+        """Generate a task comparing whether two written intervals are enharmonically equivalent."""
+        style = self.config.random_style()
+        accidental_limit = self.config.max_accidental
+        max_interval_number = self.config.max_interval_number
+        yes = random.choice([True, False])
+        start1, end1, quality1, number1 = self._sample_constructed_pair(
+            max_number=max_interval_number,
+            max_accidental=accidental_limit,
+        )
+        first_interval = Interval(quality1, number1, start1, end1)
+        if yes:
+            candidates = []
+            start_spellings = start1.exact_pitch_spellings(accidental_limit)
+            end_spellings = end1.exact_pitch_spellings(accidental_limit)
+            for start2 in start_spellings:
+                for end2 in end_spellings:
+                    if (
+                        start1.same_spelling(start2, include_octave=True)
+                        and end1.same_spelling(end2, include_octave=True)
+                    ):
+                        continue
+                    try:
+                        candidate_interval = Interval.between(start2, end2)
+                    except ValueError:
+                        continue
+                    if candidate_interval.number <= max_interval_number + 1:
+                        candidates.append(candidate_interval)
+            if not candidates:
+                raise ValueError("Could not construct an enharmonically equivalent interval pair.")
+            second_interval = random.choice(candidates)
+        else:
+            for _ in range(GENERATION_RETRY_LIMIT):
+                start2, end2, quality2, number2 = self._sample_constructed_pair(
+                    max_number=max_interval_number,
+                    max_accidental=accidental_limit,
+                )
+                second_interval = Interval(quality2, number2, start2, end2)
+                if not first_interval.same_endpoint_pitches(second_interval):
+                    break
+            else:
+                raise ValueError("Could not construct a distinct interval pair.")
+        start2 = second_interval.start
+        end2 = second_interval.end
+        resolution_cot = []
+        if style == FULL_ABC_SCORE_STYLE:
+            rendered_first, first_rendered_notes, first_context = ABCContext.interval_score_with_resolution(start1, end1)
+            rendered_second, second_rendered_notes, second_context = ABCContext.interval_score_with_resolution(start2, end2)
+            resolution_cot = [
+                *[first_context.resolution_sentence(note) for note in first_rendered_notes],
+                *[second_context.resolution_sentence(note) for note in second_rendered_notes],
+            ]
+            prompt = PromptFormatter.choice_prompt(
+                ENHARMONIC_INTERVAL_SCORE_OPENERS,
+                ABC_PAIR_YES_NO_TAILS,
+                tail_separator="\n",
+                first=rendered_first,
+                second=rendered_second,
+            )
+        else:
+            rendered_first = NoteRenderer.pair(start1, end1, style)
+            rendered_second = NoteRenderer.pair(start2, end2, style)
+            prompt = PromptFormatter.choice_prompt(
+                ENHARMONIC_INTERVAL_OPENERS,
+                YES_NO_TAILS,
+                style=style,
+                first=rendered_first,
+                second=rendered_second,
+            )
+        start_pitches_match = start1.same_pitch(start2)
+        end_pitches_match = end1.same_pitch(end2)
+        cot_note_style = COMPACT_ABC_STYLE if style == FULL_ABC_SCORE_STYLE else style
+        force_natural_in_cot = style == FULL_ABC_SCORE_STYLE
+        rendered_start1 = NoteRenderer.note(start1, cot_note_style, force_natural=force_natural_in_cot)
+        rendered_start2 = NoteRenderer.note(start2, cot_note_style, force_natural=force_natural_in_cot)
+        rendered_end1 = NoteRenderer.note(end1, cot_note_style, force_natural=force_natural_in_cot)
+        rendered_end2 = NoteRenderer.note(end2, cot_note_style, force_natural=force_natural_in_cot)
+        cot = resolution_cot + [
+            f"Compare endpoint pitches: {rendered_start1} and {rendered_start2} "
+            f"{'represent the same pitch' if start_pitches_match else 'do not represent the same pitch'}; "
+            f"{rendered_end1} and {rendered_end2} "
+            f"{'represent the same pitch' if end_pitches_match else 'do not represent the same pitch'}."
+        ]
+        if yes:
+            cot.append("Both corresponding endpoint pitches match, so the written intervals are enharmonically equivalent and the answer is yes.")
+        else:
+            cot.append(
+                "At least one corresponding endpoint pitch differs, so the written intervals are not enharmonically equivalent and the answer is no."
+            )
+        return self._problem(
+            "enharmonic_interval_comparison",
+            prompt,
+            "yes" if yes else "no",
+            "yes_no",
+            cot,
+            style=style,
+            first_start_note=start1.name(),
+            first_interval_quality=first_interval.quality,
+            first_interval_number=first_interval.number,
+            second_start_note=start2.name(),
+            second_interval_quality=second_interval.quality,
+            second_interval_number=second_interval.number,
+        )
+
+    def _generate_instrument_transposition(self) -> Problem:
+        """Generate a task converting written transposing-instrument pitch to sound."""
+        style = self.config.random_style()
+        accidental_limit = self.config.max_accidental
+        instrument, quality, number = random.choice(TRANSPOSING_INSTRUMENTS)
+        written = Note.random(self.config, accidental_limit=accidental_limit)
+        transposition = Interval(quality, number)
+        sounding = transposition.construct_from(written, direction="down")
+        interval = transposition.name()
+        answer_style, answer_notation, force_answer_natural = NoteRenderer.answer_rendering(style)
+        answer = NoteRenderer.note(sounding, answer_style, force_natural=force_answer_natural, quote_abc=False)
+        rendered_sounding = NoteRenderer.note(sounding, answer_style, force_natural=force_answer_natural)
+        answer_format = NoteRenderer.answer_format(answer_notation, explicit_accidentals=force_answer_natural)
+        instrument_article_lower = TextFormatter.article(instrument)
+        instrument_article = TextFormatter.capitalize_initial(instrument_article_lower)
+        if style == FULL_ABC_SCORE_STYLE:
+            rendered_written, rendered_written_notes, resolution_cot = NoteRenderer.sequence([written], style)
+            prompt = PromptFormatter.choice_prompt(
+                INSTRUMENT_TRANSPOSITION_SCORE_OPENERS,
+                NOTE_ANSWER_TAILS,
+                style=style,
+                notation_separator="\n",
+                score=rendered_written,
+                instrument_article=instrument_article,
+                instrument_article_lower=instrument_article_lower,
+                answer_format=answer_format,
+            )
+            cot_written = rendered_written_notes[0]
+            cot = resolution_cot
+        else:
+            rendered_written = NoteRenderer.note(written, style)
+            prompt = PromptFormatter.choice_prompt(
+                INSTRUMENT_TRANSPOSITION_OPENERS,
+                NOTE_ANSWER_TAILS,
+                style=style,
+                instrument_article=instrument_article,
+                instrument_article_lower=instrument_article_lower,
+                written=rendered_written,
+                answer_format=answer_format,
+            )
+            cot_written = rendered_written
+            cot = []
+        cot += [
+            f"{TextFormatter.capitalize_initial(instrument)} sounds {TextFormatter.article(interval)} lower than written.",
+            f"Moving {cot_written} down {TextFormatter.article(interval)} gives {rendered_sounding}.",
+        ]
+        return self._problem(
+            "instrument_transposition",
+            prompt,
+            answer,
+            "note",
+            cot,
+            instrument=instrument,
+            written_note=written.name(),
+            answer_notation=answer_notation,
+            style=style,
+        )
+
+    def _generate_interval_construction(self) -> Problem:
+        """Generate a task constructing a note above or below another by interval name."""
+        style = self.config.random_style()
+        accidental_limit = self.config.max_accidental
+        max_interval_number = self.config.max_interval_number
+        start = Note.random(self.config, accidental_limit=accidental_limit)
+        interval = Interval.random(
+            self.config,
+            min_number=2,
+            max_number=max_interval_number,
+            accidental_limit=accidental_limit,
+        )
+        direction = random.choice(["up", "down"])
+        position = "above" if direction == "up" else "below"
+        end = interval.construct_from(start, direction=direction)
+        prompt_answer_case = random.choice(INTERVAL_CONSTRUCTION_CASES)
+        prompt_has_octave = prompt_answer_case != "prompt_no_octave_answer_no_octave"
+        answer_has_octave = prompt_answer_case == "prompt_octave_answer_octave"
+        reduce_to_note_name = prompt_has_octave and not answer_has_octave
+        answer_style, answer_notation, force_answer_natural = NoteRenderer.answer_rendering(style)
+        answer_note = end if answer_has_octave else end.without_octave()
+        answer = NoteRenderer.note(
+            answer_note,
+            answer_style,
+            with_octave=answer_has_octave,
+            force_natural=force_answer_natural,
+            quote_abc=False,
+        )
+        rendered_answer = NoteRenderer.note(
+            answer_note,
+            answer_style,
+            with_octave=answer_has_octave,
+            force_natural=force_answer_natural,
+        )
+        prompt_start = start if prompt_has_octave else start.without_octave()
+        cot_start = NoteRenderer.note(
+            prompt_start,
+            answer_style,
+            with_octave=prompt_has_octave,
+            force_natural=style == FULL_ABC_SCORE_STYLE,
+        )
+        cot_end = NoteRenderer.note(
+            end,
+            answer_style,
+            with_octave=prompt_has_octave,
+            force_natural=force_answer_natural,
+        )
+        interval_name = interval.name()
+        simple_number_name = interval.number_name
+        interval_size = interval.semitones
+        prompt_answer_format = NoteRenderer.answer_format(
+            answer_notation,
+            with_octave=answer_has_octave,
+            explicit_accidentals=force_answer_natural,
+        )
+        followup = "Then reduce the result to a note name without octave. " if reduce_to_note_name else ""
+        construction_tails = tuple(f"{followup}{tail}" for tail in NOTE_ANSWER_TAILS)
+        resolution_cot = []
+        if style == FULL_ABC_SCORE_STYLE:
+            rendered_start_score, _, resolution_cot = NoteRenderer.sequence(
+                [prompt_start],
+                style,
+                with_octave=prompt_has_octave,
+            )
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_CONSTRUCTION_SCORE_OPENERS,
+                construction_tails,
+                style=style,
+                notation_separator="\n",
+                interval=TextFormatter.article(interval_name),
+                position=position,
+                score=rendered_start_score,
+                answer_format=prompt_answer_format,
+            )
+        else:
+            prompt = PromptFormatter.choice_prompt(
+                INTERVAL_CONSTRUCTION_OPENERS,
+                construction_tails,
+                style=style,
+                interval=TextFormatter.article(interval_name),
+                position=position,
+                start=NoteRenderer.note(prompt_start, style),
+                answer_format=prompt_answer_format,
+            )
+        cot = resolution_cot + [
+            f"Start from {cot_start}.",
+            f"For {TextFormatter.article(simple_number_name)}, the target letter is found by moving {TextFormatter.count_phrase(interval.step_count, 'letter step')} {direction} from {start.letter}, which gives {end.letter}.",
+            f"The major/perfect reference form of {TextFormatter.article(simple_number_name)} spans {TextFormatter.count_phrase(interval.base_semitones)}; {TextFormatter.article(interval_name)} must span {TextFormatter.count_phrase(interval_size)}.",
+            f"With letter {end.letter}, the spelling that gives this semitone distance is {cot_end}.",
+            (
+                f"The no-octave form of the result is {rendered_answer}."
+                if prompt_answer_case == "prompt_octave_answer_no_octave"
+                else f"So the answer is {rendered_answer}."
+            ),
+        ]
+        return self._problem(
+            "interval_construction",
+            prompt,
+            answer,
+            "note",
+            cot,
+            start_note=start.name(),
+            interval_quality=interval.quality,
+            interval_number=interval.number,
+            direction=direction,
+            answer_notation=answer_notation,
+            prompt_has_octave=prompt_has_octave,
+            answer_has_octave=answer_has_octave,
+            style=style,
+        )
+
+    def _generate_transposition_chain(self) -> Problem:
+        """Generate a task applying several interval transpositions in sequence."""
+        style = self.config.random_style()
+        answer_style, answer_notation, force_answer_natural = NoteRenderer.answer_rendering(style)
+        max_interval_number = self.config.max_interval_number
+        max_accidental = self.config.max_accidental
+        steps = []
+        current = Note.random(
+            self.config,
+            with_octave=True,
+            octave_min=4,
+            octave_max=4,
+            accidental_limit=max_accidental,
+        )
+        start = current
+        chain_len = self.config.chain_len
+        for _ in range(chain_len):
+            direction, interval, nxt = self._sample_transposition_step(
+                current,
+                max_interval_number,
+                max_accidental,
+            )
+            steps.append((direction, interval, current.without_octave(), nxt.without_octave()))
+            current = nxt
+        step_text = ", ".join(f"{direction} {TextFormatter.article(interval.name())}" for direction, interval, _, _ in steps)
+        answer = NoteRenderer.note(
+            current.without_octave(),
+            answer_style,
+            with_octave=False,
+            force_natural=force_answer_natural,
+            quote_abc=False,
+        )
+        answer_format = NoteRenderer.answer_format(
+            answer_notation,
+            with_octave=False,
+            explicit_accidentals=force_answer_natural,
+        )
+        resolution_cot = []
+        if style == FULL_ABC_SCORE_STYLE:
+            rendered_start_score, _, resolution_cot = NoteRenderer.sequence(
+                [start.without_octave()],
+                style,
+                with_octave=False,
+            )
+            prompt = PromptFormatter.choice_prompt(
+                TRANSPOSITION_CHAIN_SCORE_OPENERS,
+                NOTE_ANSWER_TAILS,
+                style=style,
+                notation_separator="\n",
+                score=rendered_start_score,
+                steps=step_text,
+                answer_format=answer_format,
+            )
+        else:
+            prompt = PromptFormatter.choice_prompt(
+                TRANSPOSITION_CHAIN_OPENERS,
+                NOTE_ANSWER_TAILS,
+                style=style,
+                start=NoteRenderer.note(start.without_octave(), style, with_octave=False),
+                steps=step_text,
+                answer_format=answer_format,
+            )
+            prompt = " ".join(prompt.split())
+        cot = resolution_cot + [
+            f"{NoteRenderer.note(before, answer_style, with_octave=False, force_natural=force_answer_natural)} "
+            f"{direction} {TextFormatter.article(interval.name())} -> "
+            f"{NoteRenderer.note(after, answer_style, with_octave=False, force_natural=force_answer_natural)}"
+            for direction, interval, before, after in steps
+        ]
+        return self._problem(
+            "transposition_chain",
+            prompt,
+            answer,
+            "note",
+            cot,
+            start_note=start.name(False),
+            steps=[
+                {
+                    "direction": direction,
+                    "interval_quality": interval.quality,
+                    "interval_number": interval.number,
+                }
+                for direction, interval, _, _ in steps
+            ],
+            answer_notation=answer_notation,
+            style=style,
+        )
+
+    def _sample_transposition_step(
+        self,
+        current: Note,
+        max_number: int,
+        max_accidental: int,
+    ) -> tuple[str, Interval, Note]:
+        """Sample one transposition step that keeps the next spelling supported."""
+        for _ in range(GENERATION_RETRY_LIMIT):
+            interval = Interval.random(
+                self.config,
+                min_number=2,
+                max_number=max_number,
+                accidental_limit=max_accidental,
+            )
+            if interval.quality not in Interval.quality_options(interval.number, max_accidental):
+                continue
+            direction = random.choice(["up", "down"])
+            try:
+                nxt = interval.construct_from(current, direction=direction)
+            except ValueError:
+                continue
+            if abs(nxt.accidental) <= max_accidental:
+                return direction, interval, nxt
+        raise ValueError("Could not sample a valid transposition-chain step.")
+
+    def _sample_interval_arithmetic_chain(self) -> tuple[Interval, list[tuple[str, Interval | None, Interval]]]:
+        """Sample a valid interval-arithmetic chain within the current difficulty."""
+        operation_count = self.config.chain_len
+        max_number = self.config.max_interval_number
+        max_accidental = self.config.max_accidental
+        if max_number < 2:
+            raise ValueError("Interval-arithmetic difficulty bounds are too small.")
+        for _ in range(GENERATION_RETRY_LIMIT):
+            start_interval = Interval.random(
+                self.config,
+                min_number=2,
+                max_number=max_number,
+                accidental_limit=max_accidental,
+            )
+            if start_interval.quality not in Interval.quality_options(start_interval.number, max_accidental):
+                continue
+            current = start_interval
+            steps = []
+            try:
+                for _ in range(operation_count):
+                    operation, operand, current = self._sample_interval_arithmetic_step(
+                        current,
+                        max_number,
+                        max_accidental,
+                    )
+                    steps.append((operation, operand, current))
+            except ValueError:
+                continue
+            return start_interval, steps
+        raise ValueError("Could not construct a suitable interval-arithmetic chain.")
+
+    def _sample_interval_arithmetic_step(
+        self,
+        current: Interval,
+        max_result_number: int,
+        max_accidental: int,
+    ) -> tuple[str, Interval | None, Interval]:
+        """Sample one valid interval-arithmetic step."""
+        for _ in range(GENERATION_RETRY_LIMIT):
+            operation = random.choice(["add", "subtract", "reduce_then_invert"])
+            try:
+                return self._sample_interval_operand(current, operation, max_result_number, max_accidental)
+            except ValueError:
+                continue
+
+        operations = ["add", "subtract", "reduce_then_invert"]
+        random.shuffle(operations)
+        for operation in operations:
+            try:
+                return self._sample_interval_operand(current, operation, max_result_number, max_accidental)
+            except ValueError:
+                continue
+        raise ValueError("Could not sample a valid interval-arithmetic step.")
+
+    def _sample_interval_operand(
+        self,
+        current: Interval,
+        operation: str,
+        max_result_number: int,
+        max_accidental: int,
+    ) -> tuple[str, Interval | None, Interval]:
+        """Sample the operand, if any, and result for one arithmetic operation."""
+        if operation == "reduce_then_invert":
+            if current.number <= 8:
+                raise ValueError("Only compound intervals can be reduced before inversion.")
+            result = current.reduced().inverted()
+            if (
+                result.number <= max_result_number
+                and result.quality in Interval.quality_options(result.number, max_accidental)
+            ):
+                return operation, None, result
+            raise ValueError("Reduce-then-invert produced an unsupported interval.")
+
+        if operation == "add":
+            max_operand_number = max_result_number - current.number + 1
+        elif operation == "subtract":
+            max_operand_number = current.number
+        else:
+            raise ValueError(f"Unsupported interval-arithmetic operation: {operation}")
+
+        if max_operand_number < 2:
+            raise ValueError("No room left for the requested interval operation.")
+        for _ in range(GENERATION_RETRY_LIMIT):
+            operand = Interval.random(
+                self.config,
+                min_number=2,
+                max_number=max_operand_number,
+                accidental_limit=max_accidental,
+            )
+            if operand.quality not in Interval.quality_options(operand.number, max_accidental):
+                continue
+            try:
+                result = current.add(operand) if operation == "add" else current.subtract(operand)
+            except ValueError:
+                continue
+            if (
+                result.number <= max_result_number
+                and result.quality in Interval.quality_options(result.number, max_accidental)
+            ):
+                return operation, operand, result
+        raise ValueError("Could not sample a valid interval operand.")
+
+    def _sample_constructed_pair(
+        self,
+        with_octave: bool = True,
+        min_number: int = 1,
+        max_number: int | None = None,
+        max_accidental: int | None = None,
+        quality: str | None = None,
+        number: int | None = None,
+    ) -> tuple[Note, Note, str, int]:
+        """Sample a start note, interval, and constructible end note."""
+        max_number = max_number or self.config.max_interval_number
+        max_accidental = self.config.max_accidental if max_accidental is None else max_accidental
+        for _ in range(GENERATION_RETRY_LIMIT):
+            start = Note.random(self.config, with_octave=True, accidental_limit=max_accidental)
+            interval = (
+                Interval(quality, number)
+                if quality and number
+                else Interval.random(
+                    self.config,
+                    min_number=min_number,
+                    max_number=max_number,
+                    accidental_limit=max_accidental,
+                )
+            )
+            end = interval.construct_from(start, direction="up")
+            if abs(end.accidental) <= max_accidental:
+                if not with_octave:
+                    return start.without_octave(), end.without_octave(), interval.quality, interval.number
+                return start, end, interval.quality, interval.number
+        raise ValueError("Could not construct a suitable interval pair.")

--- a/tests/test_chord_roman_reasoning.py
+++ b/tests/test_chord_roman_reasoning.py
@@ -1,0 +1,462 @@
+import random
+import re
+
+import pytest
+from music21 import chord as music21_chord
+from music21 import key as music21_key
+from music21 import roman as music21_roman
+
+from reasoning_core.template import Problem
+from reasoning_core.tasks._music_theory import (
+    AnswerNormalizer,
+    COMPACT_ABC_STYLE,
+    FULL_ABC_SCORE_STYLE,
+    Music21Adapter,
+    Note,
+    SPN_STYLE,
+    key_tonics,
+)
+from reasoning_core.tasks.chord_roman_reasoning import (
+    CHROMATIC_CHORDS,
+    CHROMATIC_SCALE_DEGREE_FORMULAS,
+    ENHARMONIC_OPENERS,
+    MODE_NAMES,
+    ROMAN_MAJOR_SECONDARY_SEVENTHS,
+    ROMAN_MAJOR_SECONDARY_TRIADS,
+    ROMAN_MINOR_SECONDARY_SEVENTHS,
+    ROMAN_MINOR_SECONDARY_TRIADS,
+    ChordRomanConfig,
+    ChordRomanReasoning,
+)
+
+
+COMMON_NAME_BY_LABEL = {
+    "major triad": "major triad",
+    "minor triad": "minor triad",
+    "diminished triad": "diminished triad",
+    "augmented triad": "augmented triad",
+    "major seventh": "major seventh chord",
+    "dominant seventh": "dominant seventh chord",
+    "minor seventh": "minor seventh chord",
+    "half-diminished seventh": "half-diminished seventh chord",
+    "fully diminished seventh": "diminished seventh chord",
+    "minor-major seventh": "minor-augmented tetrachord",
+    "augmented-major seventh": "augmented major tetrachord",
+}
+
+
+def _problem(answer, answer_kind="text", **metadata):
+    return Problem(metadata={"answer_kind": answer_kind, **metadata}, answer=answer)
+
+
+def _music21_key_from_label(label):
+    tonic, mode = label.split(maxsplit=1)
+    if mode == "minor":
+        return music21_key.Key(tonic, "minor")
+    return music21_key.Key(tonic)
+
+
+def _pitch_class(note_name, answer_notation=None):
+    normalized = AnswerNormalizer.note(note_name, answer_notation)
+    if type(answer_notation) == str and "ABC" in answer_notation:
+        match = re.fullmatch(r"(\^\^|__|\^|_|=)?([A-Ga-g])([,']*)", normalized)
+        if not match:
+            raise ValueError(f"Invalid compact ABC note: {note_name!r}")
+        accidental_token, letter, _octave_marks = match.groups()
+        accidental = {"^^": 2, "^": 1, None: 0, "=": 0, "_": -1, "__": -2}[accidental_token]
+        return Note(letter.upper(), accidental).pc
+    return Note.parse(normalized).pc
+
+
+def _pitch_classes(note_names, answer_notation=None):
+    return {_pitch_class(note, answer_notation) for note in note_names}
+
+
+def _music21_pitch_name(note_name):
+    return note_name.replace("bb", "--").replace("b", "-")
+
+
+@pytest.mark.parametrize("mode", MODE_NAMES)
+def test_generated_examples_have_valid_answers_for_each_mode(mode):
+    random.seed(2000 + MODE_NAMES.index(mode))
+    task = ChordRomanReasoning(ChordRomanConfig(mode=mode))
+
+    for level in [0, 3, 5]:
+        example = task.generate_example(level=level)
+
+        assert example.metadata.mode == mode
+        assert example.prompt
+        assert example.metadata.cot
+        assert task.score_answer(example.answer, example) == 1.0
+
+
+def test_chord_quality_labels_match_music21_common_names():
+    random.seed(3100 + MODE_NAMES.index("chord_quality"))
+    task = ChordRomanReasoning(ChordRomanConfig(mode="chord_quality"))
+
+    seen_sizes = set()
+    for _ in range(60):
+        example = task.generate_example(level=5)
+        seen_sizes.add(len(example.metadata.chord_notes))
+        chord = music21_chord.Chord([_music21_pitch_name(note) for note in example.metadata.chord_notes])
+
+        assert chord.commonName == COMMON_NAME_BY_LABEL[example.answer]
+
+    assert seen_sizes == {3, 4}
+
+
+def test_enharmonic_chord_equivalence_samples_chords_with_and_without_octaves():
+    seen_octave_settings = set()
+
+    for seed in range(7000, 7060):
+        random.seed(seed)
+        task = ChordRomanReasoning(ChordRomanConfig(mode="enharmonic_chord_equivalence"))
+        example = task.generate_example(level=5)
+        seen_octave_settings.add(example.metadata.with_octave)
+
+        assert task.score_answer(example.answer, example) == 1.0
+        assert all(
+            any(char.isdigit() for char in note) == example.metadata.with_octave
+            for note in example.metadata.first_chord
+        )
+        assert all(
+            any(char.isdigit() for char in note) == example.metadata.with_octave
+            for note in example.metadata.second_chord
+        )
+
+    assert seen_octave_settings == {False, True}
+
+
+def test_full_abc_chord_prompts_do_not_duplicate_chord_phrases():
+    chord_prompt_modes = [
+        "chord_quality",
+        "inversion",
+        "open_close_voicing",
+        "enharmonic_chord_equivalence",
+        "chromatic_chord_label",
+        "chord_membership",
+        "roman_numeral_from_chord",
+    ]
+    bad_fragments = [
+        "the chord the chord",
+        "chord tones the chord",
+        "chord-tone collection the chord",
+        "the chromatic chord the chord",
+        "written chords the chord",
+    ]
+
+    for mode in chord_prompt_modes:
+        random.seed(8100 + MODE_NAMES.index(mode))
+        config = ChordRomanConfig(mode=mode)
+        config.random_style = lambda: FULL_ABC_SCORE_STYLE
+        task = ChordRomanReasoning(config)
+        example = task.generate_example(level=5)
+
+        assert not any(fragment in example.prompt for fragment in bad_fragments)
+
+
+def test_full_abc_chord_prompts_include_key_resolution_cot():
+    chord_prompt_modes = [
+        "chord_quality",
+        "inversion",
+        "open_close_voicing",
+        "enharmonic_chord_equivalence",
+        "chromatic_chord_label",
+        "chord_membership",
+        "roman_numeral_from_chord",
+    ]
+
+    for mode in chord_prompt_modes:
+        random.seed(9100 + MODE_NAMES.index(mode))
+        config = ChordRomanConfig(mode=mode)
+        config.random_style = lambda: FULL_ABC_SCORE_STYLE
+        task = ChordRomanReasoning(config)
+        example = task.generate_example(level=5)
+
+        assert "ABC score fragment" in example.prompt
+        assert "Interpret the score using its key signature" in example.prompt
+        assert "score note" in example.metadata.cot
+
+
+def test_chromatic_chord_labels_match_music21_roman_spellings():
+    random.seed(4100)
+    task = ChordRomanReasoning(ChordRomanConfig(mode="chromatic_chord_label"))
+    known_figures = {label: figure for label, figure in CHROMATIC_CHORDS}
+    seen_modes = set()
+    seen_octave_settings = set()
+
+    for _ in range(60):
+        example = task.generate_example(level=5)
+        seen_modes.add(example.metadata.key.split(maxsplit=1)[1])
+        seen_octave_settings.add(example.metadata.with_octave)
+        rn = music21_roman.RomanNumeral(
+            known_figures[example.answer],
+            _music21_key_from_label(example.metadata.key),
+        )
+        expected_chord_notes = [
+            (pitch.nameWithOctave if example.metadata.with_octave else pitch.name).replace("-", "b")
+            for pitch in rn.pitches
+        ]
+        expected_bass_note = (
+            rn.bass().nameWithOctave
+            if example.metadata.with_octave
+            else rn.bass().name
+        ).replace("-", "b")
+
+        assert expected_chord_notes == example.metadata.chord_notes
+        assert expected_bass_note == example.metadata.bass_note
+        assert f"scale-degree formula is {CHROMATIC_SCALE_DEGREE_FORMULAS[example.answer]}" in example.metadata.cot
+
+    assert seen_modes == {"major", "minor"}
+    assert seen_octave_settings == {False, True}
+
+
+def test_chromatic_chord_label_arrangement_cot_matches_octave_policy():
+    seen_octave_settings = set()
+
+    for seed in range(9200, 9300):
+        random.seed(seed)
+        task = ChordRomanReasoning(ChordRomanConfig(mode="chromatic_chord_label"))
+        example = task.generate_example(level=5)
+        seen_octave_settings.add(example.metadata.with_octave)
+        arrangement_phrase = "Arrange the chord tones from the specified bass upward"
+
+        if example.metadata.with_octave:
+            assert arrangement_phrase not in example.metadata.cot
+        else:
+            assert arrangement_phrase in example.metadata.cot
+
+    assert seen_octave_settings == {False, True}
+
+
+@pytest.mark.parametrize("mode", ["chord_membership", "roman_numeral_from_chord"])
+def test_chord_context_modes_sample_chords_with_and_without_octaves(mode):
+    seen_octave_settings = set()
+
+    for seed in range(8200, 8260):
+        random.seed(seed + MODE_NAMES.index(mode))
+        task = ChordRomanReasoning(ChordRomanConfig(mode=mode))
+        example = task.generate_example(level=5)
+        seen_octave_settings.add(example.metadata.with_octave)
+
+        assert task.score_answer(example.answer, example) == 1.0
+        assert all(
+            any(char.isdigit() for char in note) == example.metadata.with_octave
+            for note in example.metadata.chord_notes
+        )
+        if mode == "roman_numeral_from_chord":
+            assert any(char.isdigit() for char in example.metadata.bass_note) == example.metadata.with_octave
+
+    assert seen_octave_settings == {False, True}
+
+
+@pytest.mark.parametrize("mode", ["roman_numeral_from_chord", "chord_from_roman_numeral"])
+def test_roman_modes_round_trip_with_music21(mode):
+    random.seed(5100 + MODE_NAMES.index(mode))
+    task = ChordRomanReasoning(ChordRomanConfig(mode=mode))
+
+    for _ in range(20):
+        example = task.generate_example(level=5)
+        rn = music21_roman.RomanNumeral(example.metadata.roman_figure, _music21_key_from_label(example.metadata.key))
+        rn_pitch_classes = {pitch.pitchClass for pitch in rn.pitches}
+        if mode == "roman_numeral_from_chord":
+            assert rn_pitch_classes == _pitch_classes(example.metadata.chord_notes)
+            assert rn.bass().pitchClass == _pitch_class(example.metadata.bass_note)
+        else:
+            assert rn_pitch_classes == _pitch_classes(example.metadata.chord_notes)
+            assert rn.bass().pitchClass == _pitch_class(example.metadata.chord_notes[0])
+            assert rn_pitch_classes == _pitch_classes(
+                AnswerNormalizer.note_sequence(
+                    example.answer,
+                    example.metadata.answer_notation,
+                ),
+                example.metadata.answer_notation,
+            )
+
+
+def test_chord_from_roman_answer_notation_follows_prompt_style():
+    expected = {
+        SPN_STYLE: ("scientific pitch notation", False),
+        COMPACT_ABC_STYLE: ("compact ABC notation", False),
+        FULL_ABC_SCORE_STYLE: ("compact ABC notation", True),
+    }
+
+    for style, (answer_notation, explicit_accidentals) in expected.items():
+        random.seed(9300)
+        config = ChordRomanConfig(mode="chord_from_roman_numeral")
+        config.random_style = lambda style=style: style
+        task = ChordRomanReasoning(config)
+        example = task.generate_example(level=5)
+
+        assert example.metadata.answer_notation == answer_notation
+        assert example.metadata.answer_explicit_accidentals is explicit_accidentals
+        assert '"' not in example.answer
+        assert task.score_answer(example.answer, example) == 1.0
+        if explicit_accidentals:
+            assert "with any accidental made explicit" in example.prompt
+
+
+def test_score_answer_normalizes_roman_and_note_sequence_answers():
+    task = ChordRomanReasoning(ChordRomanConfig(mode="chord_from_roman_numeral"))
+
+    assert task.score_answer(" V 6 5. ", _problem("V65", answer_kind="roman")) == 1.0
+    assert task.score_answer("vii/o65", _problem("viiø65", answer_kind="roman")) == 1.0
+    assert task.score_answer("C# - E - G", _problem("C#-E-G", answer_kind="note_sequence")) == 1.0
+    assert (
+        task.score_answer(
+            "C - ^F",
+            _problem("=C-^F", answer_kind="note_sequence", answer_notation="compact ABC notation"),
+        )
+        == 1.0
+    )
+    assert task.score_answer("yes", _problem("yes", answer_kind="yes_no")) == 1.0
+    assert task.score_answer("major   triad.", _problem("major triad", answer_kind="label")) == 1.0
+    assert AnswerNormalizer.text("Major   Triad.") == "major triad"
+
+
+def test_enharmonic_openers_use_clear_pitch_class_wording():
+    assert not any("sound as the same pitch-class set" in opener for opener in ENHARMONIC_OPENERS)
+    assert any("represent the same pitch-class set" in opener for opener in ENHARMONIC_OPENERS)
+
+
+def test_roman_figure_sampling_uses_mode_specific_diatonic_pools(monkeypatch):
+    config = ChordRomanConfig(mode="roman_numeral_from_chord")
+    monkeypatch.setattr(random, "random", lambda: 1.0)
+    task = ChordRomanReasoning(config)
+
+    task._sample_chord_size = lambda: 3
+    major_triads = {task._sample_roman_figure("major") for _ in range(100)}
+    minor_triads = {task._sample_roman_figure("minor") for _ in range(100)}
+    triad_suffixes = ("", "6", "64")
+    assert major_triads <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ("I", "ii", "iii", "IV", "V", "vi", "viio")
+        for suffix in triad_suffixes
+    }
+    assert minor_triads <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ("i", "iio", "III", "iv", "V", "VI", "viio")
+        for suffix in triad_suffixes
+    }
+
+    task._sample_chord_size = lambda: 4
+    major_sevenths = {task._sample_roman_figure("major") for _ in range(100)}
+    minor_sevenths = {task._sample_roman_figure("minor") for _ in range(100)}
+    seventh_suffixes = ("7", "65", "43", "42")
+    assert major_sevenths <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ("I7", "ii7", "iii7", "IV7", "V7", "vi7", "vii/o7")
+        for suffix in seventh_suffixes
+    }
+    assert minor_sevenths <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ("i7", "ii/o7", "III7", "iv7", "V7", "VI7", "viio7")
+        for suffix in seventh_suffixes
+    }
+
+
+def test_roman_figure_sampling_uses_mode_specific_secondary_pools(monkeypatch):
+    config = ChordRomanConfig(mode="roman_numeral_from_chord")
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    task = ChordRomanReasoning(config)
+
+    task._sample_chord_size = lambda: 3
+    major_triads = {task._sample_roman_figure("major") for _ in range(100)}
+    minor_triads = {task._sample_roman_figure("minor") for _ in range(100)}
+    triad_suffixes = ("", "6", "64")
+    assert major_triads <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ROMAN_MAJOR_SECONDARY_TRIADS
+        for suffix in triad_suffixes
+    }
+    assert minor_triads <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ROMAN_MINOR_SECONDARY_TRIADS
+        for suffix in triad_suffixes
+    }
+
+    task._sample_chord_size = lambda: 4
+    major_sevenths = {task._sample_roman_figure("major") for _ in range(100)}
+    minor_sevenths = {task._sample_roman_figure("minor") for _ in range(100)}
+    seventh_suffixes = ("7", "65", "43", "42")
+    assert major_sevenths <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ROMAN_MAJOR_SECONDARY_SEVENTHS
+        for suffix in seventh_suffixes
+    }
+    assert minor_sevenths <= {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in ROMAN_MINOR_SECONDARY_SEVENTHS
+        for suffix in seventh_suffixes
+    }
+
+
+@pytest.mark.parametrize(
+    ("mode", "triad_pool", "seventh_pool"),
+    [
+        ("major", ROMAN_MAJOR_SECONDARY_TRIADS, ROMAN_MAJOR_SECONDARY_SEVENTHS),
+        ("minor", ROMAN_MINOR_SECONDARY_TRIADS, ROMAN_MINOR_SECONDARY_SEVENTHS),
+    ],
+)
+def test_secondary_roman_pools_parse_in_all_supported_keys(mode, triad_pool, seventh_pool):
+    key_names = key_tonics(mode, 7)
+    triad_figures = {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in triad_pool
+        for suffix in ("", "6", "64")
+    }
+    seventh_figures = {
+        ChordRomanReasoning._with_roman_inversion(base, suffix)
+        for base in seventh_pool
+        for suffix in ("7", "65", "43", "42")
+    }
+
+    for key_name in key_names:
+        key_context = (
+            music21_key.Key(key_name)
+            if mode == "major"
+            else music21_key.Key(key_name, "minor")
+        )
+        for figure in triad_figures | seventh_figures:
+            rn = music21_roman.RomanNumeral(figure, key_context)
+            notes = [Music21Adapter.note_from_pitch(pitch) for pitch in rn.pitches]
+
+            assert all(abs(note.accidental) <= 2 for note in notes)
+
+
+def test_roman_inversion_suffixes_attach_to_chord_part():
+    assert ChordRomanReasoning._with_roman_inversion("I7", "7") == "I7"
+    assert ChordRomanReasoning._with_roman_inversion("I7", "65") == "I65"
+    assert ChordRomanReasoning._with_roman_inversion("vii/o7", "65") == "vii/o65"
+    assert ChordRomanReasoning._with_roman_inversion("V7/V", "43") == "V43/V"
+    assert ChordRomanReasoning._with_roman_inversion("viio7/V", "42") == "viio42/V"
+
+
+def test_key_complexity_limits_analytical_key_tonics():
+    assert set(key_tonics("major", 0)) == {"C"}
+    assert set(key_tonics("minor", 0)) == {"A"}
+    assert set(key_tonics("major", 2)) == {"C", "G", "D", "F", "Bb"}
+    assert set(key_tonics("minor", 2)) == {"A", "E", "B", "D", "G"}
+    assert len(key_tonics("major", 7)) == 15
+    assert len(key_tonics("minor", 7)) == 15
+
+
+def test_mode_any_samples_supported_modes_and_scores_answers():
+    random.seed(6200)
+    task = ChordRomanReasoning(ChordRomanConfig(mode="any"))
+    seen_modes = set()
+
+    for _ in range(100):
+        example = task.generate_example(level=3)
+        seen_modes.add(example.metadata.mode)
+        assert example.metadata.mode in MODE_NAMES
+        assert task.score_answer(example.answer, example) == 1.0
+
+    assert len(seen_modes) > 1
+
+
+def test_unknown_mode_is_rejected_before_retry_loop():
+    task = ChordRomanReasoning(ChordRomanConfig(mode="not_a_mode"))
+
+    with pytest.raises(ValueError, match="Unknown chord Roman mode"):
+        task.generate()

--- a/tests/test_music_theory.py
+++ b/tests/test_music_theory.py
@@ -1,0 +1,333 @@
+import random
+
+import pytest
+from music21 import converter as music21_converter
+from music21 import interval as music21_interval
+from music21 import pitch as music21_pitch
+
+from reasoning_core.tasks._music_theory import (
+    ABC_KEY_SIGNATURES,
+    ABCContext,
+    AnswerNormalizer,
+    COMPACT_ABC_STYLE,
+    ChordRenderer,
+    ChordTools,
+    FULL_ABC_SCORE_STYLE,
+    Interval,
+    Music21Adapter,
+    Note,
+    NoteRenderer,
+    Scale,
+    SPN_STYLE,
+)
+
+
+ACCIDENTAL_NAMES = {
+    -2: "double-flat",
+    -1: "flat",
+    0: None,
+    1: "sharp",
+    2: "double-sharp",
+}
+
+MUSIC21_INTERVAL_QUALITIES = {
+    "perfect": "P",
+    "major": "M",
+    "minor": "m",
+    "augmented": "A",
+    "diminished": "d",
+    "double-augmented": "AA",
+    "double-diminished": "dd",
+}
+
+
+def _to_music21_pitch(note):
+    result = music21_pitch.Pitch()
+    result.step = note.letter
+    result.octave = note.octave
+    accidental_name = ACCIDENTAL_NAMES[note.accidental]
+    result.accidental = None if accidental_name is None else music21_pitch.Accidental(accidental_name)
+    return result
+
+
+def _from_music21_pitch(pitch):
+    accidental = 0 if pitch.accidental is None else int(pitch.accidental.alter)
+    return Note(pitch.step, accidental, pitch.octave)
+
+
+def _to_music21_interval(interval_value):
+    quality = MUSIC21_INTERVAL_QUALITIES[interval_value.quality]
+    return music21_interval.Interval(f"{quality}{interval_value.number}")
+
+
+@pytest.mark.parametrize(
+    ("note", "expected_name", "expected_name_without_octave", "expected_pc"),
+    [
+        (Note("C", 0, 4), "C4", "C", 0),
+        (Note("F", 1, 3), "F#3", "F#", 6),
+        (Note("B", -1, 5), "Bb5", "Bb", 10),
+        (Note("E", 2, 2), "E##2", "E##", 6),
+        (Note("C", -2, None), "Cbb", "Cbb", 10),
+    ],
+)
+def test_note_names_and_pitch_classes(note, expected_name, expected_name_without_octave, expected_pc):
+    assert note.name() == expected_name
+    assert note.pc == expected_pc
+    assert note.without_octave().octave is None
+    assert note.without_octave().name() == expected_name_without_octave
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("E-flat4", Note("E", -1, 4)),
+        ("F double-sharp 3", Note("F", 2, 3)),
+        ("c natural", Note("C", 0, None)),
+        ("Bb", Note("B", -1, None)),
+    ],
+)
+def test_note_parse_accepts_common_spellings(text, expected):
+    assert Note.parse(text) == expected
+
+
+def test_note_parse_rejects_invalid_note_name():
+    with pytest.raises(ValueError, match="Invalid note name"):
+        Note.parse("H#4")
+
+
+def test_note_exact_pitch_spellings_are_pitch_equivalent():
+    note = Note("C", 1, 4)
+    spellings = note.exact_pitch_spellings(accidental_limit=2)
+    music21_target = _to_music21_pitch(note).ps
+
+    assert Note("B", 2, 3) in spellings
+    assert Note("D", -1, 4) in spellings
+    assert all(_to_music21_pitch(spelling).ps == music21_target for spelling in spellings)
+
+
+def test_note_spellings_for_pitch_class_can_omit_octaves():
+    spellings = Note.spellings_for_pitch_class(1, accidental_limit=2, with_octave=False)
+
+    assert Note("C", 1) in spellings
+    assert Note("D", -1) in spellings
+    assert all(note.octave is None for note in spellings)
+    assert all(note.pc == 1 for note in spellings)
+
+
+@pytest.mark.parametrize(
+    "interval_value",
+    [
+        Interval("perfect", 1),
+        Interval("minor", 2),
+        Interval("major", 3),
+        Interval("augmented", 4),
+        Interval("double-diminished", 5),
+        Interval("minor", 10),
+        Interval("major", 13),
+        Interval("perfect", 15),
+        Interval("double-augmented", 8),
+    ],
+)
+def test_interval_semitones_match_music21(interval_value):
+    expected_interval = _to_music21_interval(interval_value)
+
+    assert interval_value.semitones == expected_interval.semitones
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        (Note("C", 0, 4), Note("E", 0, 4), Interval("major", 3)),
+        (Note("F", 1, 3), Note("A", 0, 4), Interval("minor", 10)),
+        (Note("C", 0, 4), Note("C", 0, 5), Interval("perfect", 8)),
+        (Note("B", 1, 3), Note("C", 1, 4), Interval("minor", 2)),
+    ],
+)
+def test_interval_between_matches_expected_and_music21_semitones(start, end, expected):
+    actual = Interval.between(start, end)
+    expected_interval = _to_music21_interval(actual)
+
+    assert actual.quality == expected.quality
+    assert actual.number == expected.number
+    assert actual.semitones == expected_interval.semitones
+
+
+def test_interval_between_without_octaves_uses_simple_ascending_convention():
+    actual = Interval.between(Note.parse("B"), Note.parse("D"), without_octaves=True)
+
+    assert actual == Interval("minor", 3)
+    with pytest.raises(ValueError, match="Chromatic distance requires concrete interval endpoints"):
+        _ = actual.chromatic_distance
+
+
+@pytest.mark.parametrize(
+    ("start", "interval_value", "direction"),
+    [
+        (Note("C", 0, 4), Interval("major", 3), "up"),
+        (Note("F", 1, 4), Interval("augmented", 4), "up"),
+        (Note("E", 0, 4), Interval("minor", 3), "down"),
+        (Note("B", -1, 4), Interval("perfect", 5), "down"),
+    ],
+)
+def test_interval_construct_from_matches_music21_transposition(start, interval_value, direction):
+    expected_interval = _to_music21_interval(interval_value)
+    music21_start = _to_music21_pitch(start)
+    reverse = direction == "down"
+    music21_result = expected_interval.transposePitch(music21_start, reverse=reverse)
+
+    assert interval_value.construct_from(start, direction=direction) == _from_music21_pitch(music21_result)
+
+
+def test_interval_construct_from_rejects_unsupported_accidental():
+    with pytest.raises(ValueError, match="unsupported accidental"):
+        Interval("double-augmented", 8).construct_from(Note("E", 1, 4), direction="up")
+
+
+def test_interval_operations_and_inversion():
+    assert Interval("major", 2).add(Interval("minor", 3)) == Interval("perfect", 4)
+    assert Interval("perfect", 5).subtract(Interval("major", 2)) == Interval("perfect", 4)
+    assert Interval("major", 10).reduced() == Interval("major", 3)
+    assert Interval("augmented", 4).inverted() == Interval("diminished", 5)
+
+    with pytest.raises(ValueError, match="invalid interval"):
+        Interval("minor", 2).subtract(Interval("major", 3))
+
+
+def test_open_voicing_randomizes_registers_while_skipping_a_chord_member():
+    random.seed(9100)
+    root_position = [
+        Note("C", 0, 4),
+        Note("E", 0, 4),
+        Note("G", 0, 4),
+        Note("B", 0, 4),
+    ]
+
+    voicings = [ChordTools.open_voicing(root_position) for _ in range(20)]
+    rendered_voicings = {tuple(note.name() for note in voicing) for voicing in voicings}
+
+    assert len(rendered_voicings) > 1
+    assert all(ChordTools.skips_chord_member(voicing, root_position) for voicing in voicings)
+    assert all(voicing[-1].semitone_number - voicing[0].semitone_number > 12 for voicing in voicings)
+    assert all(max(note.octave for note in voicing) <= 7 for voicing in voicings)
+
+
+def test_scale_build_and_relation_labels():
+    c_major = Scale.build(Note.parse("C"), "major")
+    assert [note.name(False) for note in c_major.degrees] == ["C", "D", "E", "F", "G", "A", "B"]
+    assert c_major.relation_label(Note.parse("C"), Note.parse("E")) == "diatonic consonance"
+    assert c_major.relation_label(Note.parse("C"), Note.parse("F")) == "diatonic dissonance"
+    assert c_major.relation_label(Note.parse("C"), Note.parse("F#")) == "chromatic alteration"
+
+    a_harmonic_minor = Scale.build(Note.parse("A"), "harmonic_minor")
+    assert [note.name(False) for note in a_harmonic_minor.degrees] == ["A", "B", "C", "D", "E", "F", "G#"]
+
+
+def test_scale_membership_is_spelling_sensitive():
+    d_sharp_minor = Scale.build(Note.parse("D#"), "natural_minor")
+
+    assert d_sharp_minor.contains(Note.parse("G#"))
+    assert not d_sharp_minor.contains(Note.parse("Ab"))
+
+
+def test_abc_context_resolves_implicit_and_explicit_accidentals():
+    context = ABCContext("1/4", "4/4", "Bb", ABC_KEY_SIGNATURES["Bb"])
+
+    implicit_flat = context.render_event(Note("B", -1, 4), duration=1, explicit_accidental=False)
+    assert implicit_flat.token == "B"
+    assert "K:Bb makes B flat" in context.resolution_sentence(implicit_flat)
+    assert 'represents "_B"' in context.resolution_sentence(implicit_flat)
+
+    explicit_sharp = context.render_event(Note("B", 1, 4), duration=1, explicit_accidental=True)
+    assert explicit_sharp.token == "^B"
+    assert "explicitly marks B sharp, overriding K:Bb" in context.resolution_sentence(explicit_sharp)
+
+
+def test_full_abc_sequence_is_parseable_and_resolves_key_signature(monkeypatch):
+    context = ABCContext("1/4", "3/4", "Bb", ABC_KEY_SIGNATURES["Bb"])
+    monkeypatch.setattr(ABCContext, "random", classmethod(lambda cls: context))
+    monkeypatch.setattr(random, "random", lambda: 0.99)
+
+    score, rendered_notes, resolution_cot = NoteRenderer.sequence(
+        [Note("B", -1, 4), Note("F", 1, 4)],
+        FULL_ABC_SCORE_STYLE,
+    )
+    parsed_score = music21_converter.parse(score, format="abc")
+    parsed_notes = list(parsed_score.flatten().notes)
+
+    assert "K:Bb" in score
+    assert rendered_notes == ['"_B"', '"^F"']
+    assert "The key signature K:Bb makes B flat" in resolution_cot[0]
+    assert "explicitly marks F sharp" in resolution_cot[1]
+    assert [note.pitch.nameWithOctave for note in parsed_notes] == ["B-4", "F#4"]
+
+
+def test_full_abc_chord_rendering_is_parseable_and_resolves_notes(monkeypatch):
+    context = ABCContext("1/8", "4/4", "D", ABC_KEY_SIGNATURES["D"])
+    monkeypatch.setattr(ABCContext, "random", classmethod(lambda cls: context))
+    monkeypatch.setattr(random, "random", lambda: 0.99)
+
+    rendered = ChordRenderer.render(
+        [Note("F", 1, 4), Note("A", 0, 4), Note("C", 1, 5)],
+        FULL_ABC_SCORE_STYLE,
+        with_octave=True,
+        shuffle=False,
+    )
+    parsed_score = music21_converter.parse(rendered.prompt_text, format="abc")
+    parsed_chords = list(parsed_score.flatten().notes)
+
+    assert len(parsed_chords) == 1
+    assert [pitch.nameWithOctave for pitch in parsed_chords[0].pitches] == ["F#4", "A4", "C#5"]
+    assert rendered.cot_text == '"^F"-"=A"-"^c"'
+    assert any("K:D makes F sharp" in line for line in rendered.resolution_cot)
+    assert any("score note \"A\" represents \"=A\"" in line for line in rendered.resolution_cot)
+
+
+def test_abc_interval_score_requires_number_for_octave_less_interval():
+    with pytest.raises(ValueError, match="requires an interval number"):
+        ABCContext.interval_score_with_resolution(Note("C"), Note("E"), with_octave=False)
+
+
+def test_answer_normalizer_accepts_music_answer_variants():
+    assert AnswerNormalizer.interval("double augmented eleventh.") == AnswerNormalizer.interval("double-augmented eleventh")
+    assert AnswerNormalizer.interval("double octave") == "perfect fifteenth"
+    assert AnswerNormalizer.note("E-flat4") == "Eb4"
+    assert AnswerNormalizer.note('"=B"', "compact ABC notation") == "B"
+    assert AnswerNormalizer.note("B", "compact ABC notation") == "B"
+
+
+def test_answer_normalizer_accepts_roman_and_note_sequence_variants():
+    assert AnswerNormalizer.roman(" vii ø 6 5. ") == "vii/o65"
+    assert AnswerNormalizer.note_sequence('"=C"-"^F"', "compact ABC notation") == ("C", "^F")
+    assert AnswerNormalizer.note_sequence("C# - E - G") == ("C#", "E", "G")
+
+
+def test_note_renderer_answer_policy_matches_prompt_style():
+    assert NoteRenderer.answer_rendering(SPN_STYLE) == (
+        SPN_STYLE,
+        "scientific pitch notation",
+        False,
+    )
+    assert NoteRenderer.answer_rendering(COMPACT_ABC_STYLE) == (
+        COMPACT_ABC_STYLE,
+        "compact ABC notation",
+        False,
+    )
+    assert NoteRenderer.answer_rendering(FULL_ABC_SCORE_STYLE) == (
+        COMPACT_ABC_STYLE,
+        "compact ABC notation",
+        True,
+    )
+    assert NoteRenderer.answer_format("compact ABC notation", with_octave=True) == (
+        "one full compact ABC pitch token"
+    )
+    assert (
+        NoteRenderer.answer_format("compact ABC notation", explicit_accidentals=True)
+        == "one note name in compact ABC notation, with any accidental made explicit"
+    )
+
+
+def test_music21_adapter_preserves_double_accidentals():
+    assert Music21Adapter.pitch_name(Note("B", -2, 3)) == "B--3"
+    assert Music21Adapter.pitch_name(Note("F", 2, 4)) == "F##4"
+    assert Music21Adapter.note_from_pitch(music21_pitch.Pitch("B--3"), with_octave=True) == Note("B", -2, 3)
+    assert Music21Adapter.note_from_pitch(music21_pitch.Pitch("F##4"), with_octave=True) == Note("F", 2, 4)

--- a/tests/test_pitch_interval_reasoning.py
+++ b/tests/test_pitch_interval_reasoning.py
@@ -1,0 +1,293 @@
+import random
+
+import pytest
+from music21 import converter as music21_converter
+
+from reasoning_core.template import Problem
+from reasoning_core.tasks._music_theory import (
+    ABC_KEY_SIGNATURES,
+    ABCContext,
+    AnswerNormalizer,
+    FULL_ABC_SCORE_STYLE,
+    Interval,
+    Note,
+    NoteRenderer,
+    Scale,
+)
+from reasoning_core.tasks.pitch_interval_reasoning import (
+    MODE_NAMES,
+    PitchIntervalConfig,
+    PitchIntervalReasoning,
+    TRANSPOSING_INSTRUMENTS,
+)
+
+
+def _problem(answer, answer_kind="text", **metadata):
+    return Problem(metadata={"answer_kind": answer_kind, **metadata}, answer=answer)
+
+
+def _abc_fragment_from_prompt(prompt):
+    lines = prompt.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("L:"))
+    end = next(
+        (i for i in range(start, len(lines)) if lines[i].startswith("Interpret ")),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+def _render_expected_note_answer(note, style, with_octave):
+    answer_style, _answer_notation, force_answer_natural = NoteRenderer.answer_rendering(style)
+    return NoteRenderer.note(
+        note,
+        answer_style,
+        with_octave=with_octave,
+        force_natural=force_answer_natural,
+        quote_abc=False,
+    )
+
+
+def test_score_answer_normalizes_music_answer_variants():
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_naming"))
+
+    assert task.score_answer(
+        "double augmented eleventh.",
+        _problem("double-augmented eleventh", answer_kind="interval"),
+    ) == 1.0
+    assert task.score_answer("double octave", _problem("perfect fifteenth", answer_kind="interval")) == 1.0
+    assert task.score_answer("B", _problem("=B", answer_kind="note", answer_notation="compact ABC notation")) == 1.0
+    assert task.score_answer('"=B"', _problem("B", answer_kind="note", answer_notation="compact ABC notation")) == 1.0
+    assert task.score_answer("4", _problem(4, answer_kind="integer")) == 1.0
+    assert task.score_answer("4.0", _problem(4, answer_kind="integer")) == 0.0
+
+
+@pytest.mark.parametrize("mode", MODE_NAMES)
+def test_generated_examples_have_valid_answers_for_each_mode(mode):
+    random.seed(1000 + MODE_NAMES.index(mode))
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode=mode))
+
+    for level in [0, 3, 5]:
+        example = task.generate_example(level=level)
+
+        assert example.metadata.mode == mode
+        assert example.prompt
+        assert example.metadata.cot
+        assert task.score_answer(example.answer, example) == 1.0
+
+
+def test_full_abc_interval_naming_prompt_contains_parseable_score(monkeypatch):
+    context = ABCContext("1/8", "4/4", "Eb", ABC_KEY_SIGNATURES["Eb"])
+    monkeypatch.setattr(PitchIntervalConfig, "random_style", lambda self: FULL_ABC_SCORE_STYLE)
+    monkeypatch.setattr(ABCContext, "random", classmethod(lambda cls: context))
+
+    random.seed(5050)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_naming"))
+    example = task.generate_example(level=3)
+    abc_fragment = _abc_fragment_from_prompt(example.prompt)
+    parsed_score = music21_converter.parse(abc_fragment, format="abc")
+    parsed_chords = list(parsed_score.flatten().notes)
+
+    assert example.metadata.style == FULL_ABC_SCORE_STYLE
+    assert "Interpret the score using its key signature" in example.prompt
+    assert "score note" in example.metadata.cot
+    assert len(parsed_chords) == 1
+    assert len(parsed_chords[0].pitches) == 2
+    assert task.score_answer(example.answer, example) == 1.0
+
+
+def test_interval_naming_answer_matches_metadata_notes():
+    random.seed(7070)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_naming"))
+
+    for _ in range(40):
+        example = task.generate_example(level=5)
+        expected = Interval.between(
+            Note.parse(example.metadata.start_note),
+            Note.parse(example.metadata.end_note),
+        ).name()
+
+        assert example.answer == expected
+
+
+def test_pitch_count_answer_matches_metadata_pitch_classes():
+    random.seed(7170)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="pitch_count"))
+
+    for _ in range(40):
+        example = task.generate_example(level=5)
+        expected = len({Note.parse(note).pc for note in example.metadata.notes})
+
+        assert int(example.answer) == expected
+
+
+def test_interval_classification_answer_matches_scale_relation():
+    random.seed(7270)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_classification"))
+
+    for _ in range(80):
+        example = task.generate_example(level=5)
+        scale = Scale.build(
+            Note.parse(example.metadata.tonic_note),
+            example.metadata.scale_mode,
+        )
+        expected = scale.relation_label(
+            Note.parse(example.metadata.start_note),
+            Note.parse(example.metadata.end_note),
+        )
+
+        assert example.answer == expected
+
+
+def test_interval_arithmetic_metadata_reconstructs_answer():
+    random.seed(7370)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_arithmetic"))
+
+    for _ in range(60):
+        example = task.generate_example(level=5)
+        current = Interval(
+            example.metadata.start_interval_quality,
+            example.metadata.start_interval_number,
+        )
+        for step in example.metadata.operations:
+            operation = step["operation"]
+            if operation == "add":
+                current = current.add(Interval(step["interval_quality"], step["interval_number"]))
+            elif operation == "subtract":
+                current = current.subtract(Interval(step["interval_quality"], step["interval_number"]))
+            elif operation == "reduce_then_invert":
+                current = current.reduced().inverted()
+            else:
+                raise AssertionError(f"Unsupported operation in metadata: {operation}")
+
+        assert AnswerNormalizer.interval(example.answer) == AnswerNormalizer.interval(current.name())
+
+
+def test_instrument_transposition_metadata_reconstructs_answer():
+    random.seed(7470)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="instrument_transposition"))
+    instruments = {
+        instrument: Interval(quality, number)
+        for instrument, quality, number in TRANSPOSING_INSTRUMENTS
+    }
+
+    for _ in range(40):
+        example = task.generate_example(level=5)
+        written = Note.parse(example.metadata.written_note)
+        sounding = instruments[example.metadata.instrument].construct_from(written, direction="down")
+        expected = _render_expected_note_answer(sounding, example.metadata.style, with_octave=True)
+
+        assert AnswerNormalizer.note(example.answer, example.metadata.answer_notation) == AnswerNormalizer.note(
+            expected,
+            example.metadata.answer_notation,
+        )
+
+
+def test_interval_construction_metadata_reconstructs_answer():
+    random.seed(7570)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_construction"))
+    seen_cases = set()
+
+    for _ in range(80):
+        example = task.generate_example(level=5)
+        seen_cases.add((example.metadata.prompt_has_octave, example.metadata.answer_has_octave))
+        start = Note.parse(example.metadata.start_note)
+        interval = Interval(
+            example.metadata.interval_quality,
+            example.metadata.interval_number,
+        )
+        target = interval.construct_from(start, direction=example.metadata.direction)
+        answer_note = target if example.metadata.answer_has_octave else target.without_octave()
+        expected = _render_expected_note_answer(
+            answer_note,
+            example.metadata.style,
+            with_octave=example.metadata.answer_has_octave,
+        )
+
+        assert AnswerNormalizer.note(example.answer, example.metadata.answer_notation) == AnswerNormalizer.note(
+            expected,
+            example.metadata.answer_notation,
+        )
+
+    assert seen_cases == {(True, True), (True, False), (False, False)}
+
+
+def test_mode_any_samples_supported_modes_and_scores_answers():
+    random.seed(2024)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="any"))
+    seen_modes = set()
+
+    for _ in range(100):
+        example = task.generate_example(level=3)
+        seen_modes.add(example.metadata.mode)
+        assert example.metadata.mode in MODE_NAMES
+        assert task.score_answer(example.answer, example) == 1.0
+
+    assert len(seen_modes) > 1
+
+
+def test_unknown_mode_is_rejected_before_retry_loop():
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="not_a_mode"))
+
+    with pytest.raises(ValueError, match="Unknown pitch interval mode"):
+        task.generate()
+
+
+def test_high_level_transposition_chain_keeps_generated_steps_valid():
+    random.seed(3030)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="transposition_chain"))
+
+    for _ in range(100):
+        example = task.generate_example(level=5)
+
+        assert len(example.metadata.steps) == example.metadata._config["chain_len"]
+        assert task.score_answer(example.answer, example) == 1.0
+        assert "unsupported accidental" not in example.metadata.cot
+
+
+def test_transposition_chain_metadata_reconstructs_answer():
+    random.seed(7670)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="transposition_chain"))
+
+    for _ in range(60):
+        example = task.generate_example(level=5)
+        current = Note.parse(example.metadata.start_note)
+        for step in example.metadata.steps:
+            interval = Interval(step["interval_quality"], step["interval_number"])
+            current = interval.construct_from(current, direction=step["direction"])
+        expected = _render_expected_note_answer(
+            current.without_octave(),
+            example.metadata.style,
+            with_octave=False,
+        )
+
+        assert AnswerNormalizer.note(example.answer, example.metadata.answer_notation) == AnswerNormalizer.note(
+            expected,
+            example.metadata.answer_notation,
+        )
+
+
+def test_interval_arithmetic_chain_length_tracks_chain_len():
+    random.seed(4040)
+    task = PitchIntervalReasoning(PitchIntervalConfig(mode="interval_arithmetic"))
+
+    example = task.generate_example(level=5)
+
+    assert len(example.metadata.operations) == example.metadata._config["chain_len"]
+    assert {step["operation"] for step in example.metadata.operations} <= {"add", "subtract", "reduce_then_invert"}
+    assert task.score_answer(example.answer, example) == 1.0
+
+
+def test_interval_classification_key_complexity_limits_tonics():
+    random.seed(6060)
+    task = PitchIntervalReasoning(
+        PitchIntervalConfig(mode="interval_classification", key_complexity=0)
+    )
+
+    for _ in range(40):
+        example = task.generate_example(level=0)
+
+        if example.metadata.scale_mode == "major":
+            assert example.metadata.tonic_note == "C"
+        else:
+            assert example.metadata.tonic_note == "A"
+        assert task.score_answer(example.answer, example) == 1.0


### PR DESCRIPTION
## Summary

- Add shared music theory utilities for notes, intervals, scales, ABC rendering, answer normalization, and chord helpers.
- Add `pitch_interval_reasoning` task family.
- Add `chord_roman_reasoning` task family.
- Add tests for shared music theory logic and both new task families.
- Add music reasoning specification documentation.

## Testing

- `python -m pytest tests/test_music_theory.py tests/test_pitch_interval_reasoning.py tests/test_chord_roman_reasoning.py`